### PR TITLE
Translate code comments to English

### DIFF
--- a/Compass129Sources/COMfile/C12COM9.ASC
+++ b/Compass129Sources/COMfile/C12COM9.ASC
@@ -46,7 +46,7 @@ J0119	ei
 	jr	c,noshift
 	ld	a,(i_limit)
 	ld	(nr_max),a
-	xor	a	;this will force a mem search mem
+	xor	a	;this will force a mem search
 	ld	(i_skipsrcmem),a	;instead of installing memory
 noshift	LD	A,(#FCC1)
 	LD	HL,#002D
@@ -112,7 +112,7 @@ J0145:	DI
 	inc	hl
 	ld	d,(hl)
 	call	print
-	ld	a,(i_skipsrcmem)	;saved version without shiftstart?
+	ld	a,(i_skipsrcmem)	;saved version without shiftboot?
 	or	a
 	jr	nz,meminst	;yes, install immediately then
 	ld	de,txt_limit	;unsaved version or with shift
@@ -134,7 +134,7 @@ meminst	ld	de,txt_inst
 	ld	de,txt_notfree
 	call	print
 	ld	a,#ae	;poke new opcode: res 5,(ix+0)
-	ld	(m_res6),a	;this serves to display the free-routine
+	ld	(m_res6),a	;this serves to revert the free-routine (as it had been changed)
 	xor	a	;just to do (had changed)
 	ld	(i_skipsrcmem),a	;default memuse in the datfile
 	jr	memsrc
@@ -252,7 +252,7 @@ stop_wacht2	ld	a,(#fbec)
 go_launch	ld	de,txt_launch
 	call	print
 
-	LD	HL,inst	;institutions
+	LD	HL,inst	;settings
 	LD	DE,kbuf
 	LD	BC,inst_end-inst
 	LDIR
@@ -278,7 +278,7 @@ free_all	call	print
 	jp	m_freeall	;segments released
 
 ;************************************************end main ,start routines
-;fill in doskernel number
+;fills in doskernel number
 ;1=DOS1 2=DOS2 or higher ;)
 fill_dosnr	LD	C,#6F
 	CALL	bdos
@@ -627,12 +627,12 @@ src_mem	CALL	m_tabel	;create table with segments
 	call	m_count_free	;if you don't have 4 segments,
 	ld	hl,3	;don't start it! The compass blocks
 	call	m_vgl_HLDE	;after all, are not allowed in tpa segments
-	jp	nc,m_freeall	;sitting, so no m_add_321 applicable
+	jp	nc,m_freeall	;so no m_add_321 applicable
 	LD	DE,buffer
 	LD	HL,compass_1	;request tpaslotsegm for cblock 1
 	CALL	m_src_dosram	;always works, after all we had 1
-	LD	DE,buffer	;the next 3 segments are always
-	ld	hl,compass_0	;because we had four segm.
+	LD	DE,buffer	;the next 3 segments can always
+	ld	hl,compass_0	;be found/located because we had four segm.
 	CALL	m_use_zet6_hl	;search for compass block 0
 	inc	hl	;skip compass block 1
 	inc	hl
@@ -649,7 +649,7 @@ src_mem	CALL	m_tabel	;create table with segments
 	ld	ix,buffer
 	ld	bc,#0109
 	call	m_usepages
-	jp	c,m_freeall	;actually not necessary
+	jp	c,m_freeall	;technically not necessary
 
 m_okee	call	m_count_free	;when you come here there are at least 2 more
 	ld	hl,1	;tpasegm left. Use this if you run out of
@@ -755,8 +755,8 @@ J25B2:	ADD	A,C
 	ld	de,tempbuffer+1	;address where maxpagenr is
 	ld	a,(de)	;take into account that the highest nums
 	dec	a	;are already out of the door
-	dec	a	;even if only 1 is gone, then fall
-	ld	(de),a	;the segments in the tpa area anyway
+	dec	a	;even if only 1 is gone,
+	ld	(de),a	;then the segments are part of the tpa area anyway
 	call	m_scanslot	;add the tpaslotsegs last
 	LD	(IX+#00),#00	;terminating zero slot code
 	or	a	;clear carry
@@ -819,7 +819,7 @@ m_manage	ld	ix,tempbuffer
 	call	m_alloc_tpa
 	;the first is for cblock1
 	;the second may be missing, it is for the label buffer
-	;if it's missing it'll be in the maintpa segm later. set
+	;if it's missing it'll be set in the maintpa segm later.
 	;Note: the last 2 bytes of tempbuffer will then be 0
 	;this is taken into account in m_add_temp
 	ld	ix,buffer	;note: 2 tpa found, then ix already good
@@ -890,15 +890,15 @@ m_try_nottpa	push	bc
 	pop	bc
 	djnz	m_try_nottpa
 	di
-	halt		;Normally we'll never reach this, could with memman
-	;256 tpasegm are never requested since a mapper
-	;counts only 256 segments and 0 is never freed.
+	halt		;Normally we'll never reach this point,
+	;as you can never request 256 tpasegm with memman,
+	;since a mapper only counts 256 segm, and 0 is never freed.
 m_ja_eindelyk	pop	bc	;get b
 	dec	ix
 	push	ix	;(save this place)
 	dec	ix
 	call	m_free_tpa
-	pop	bc	;get that place where it didn't stand
+	pop	bc	;get that place/spot where the 'not-tpa' was located.
 	ld	a,(bc)	;get segment num
 	ld	e,a
 	dec	bc
@@ -947,10 +947,10 @@ m_Mm_alloc	PUSH	IX
 	POP	IX
 	LD	A,H
 	OR	L
-	SCF		;hl=0000 =segments are up
+	SCF		;hl=0000 =segments are used up
 	RET	Z
 	LD	B,L	;Memman segment code appears to consist of
-	LD	A,H	;H=mapperblock L=lock code
+	LD	A,H	;H=mapperblock L=slot code
 	CCF
 	RET
 
@@ -974,7 +974,7 @@ m_vgl_HLDE	LD	A,H
 	RET
 
 m_freeall	ld	a,#b6	;poke new opcode: res 6,(ix+0)
-	ld	(m_res6),a	;as a result, the used
+	ld	(m_res6),a	;as a result, also the used
 m_free	LD	A,(stat_mem)
 	OR	A
 	scf
@@ -983,15 +983,15 @@ m_free	LD	A,(stat_mem)
 m_freenext	INC	IX
 	INC	IX
 	db	#DD,#CB,0	;res 5,(ix+0): so this does nothing
-m_res6	db	#AE	;to free-en EVERYTHING: poke here #B6
+m_res6	db	#AE	;to free EVERYTHING: poke here #B6
 	LD	A,(IX+#00)	;this is opcode for res 6,(ix+0)
 	OR	A
 	scf
 	RET	Z	;done
 	bit	4,a	;is it a tpa segment?
 	jr	nz,m_freenext	;yes, don't free it then
-	BIT	6,A	;do not free segments in use and they
-	JR	NZ,m_bit6seg	;give the reserved status under memman
+	BIT	6,A	;do not free segments that are in use,
+	JR	NZ,m_bit6seg	;and give them the reserved status under memman
 	ld	b,a	;slot code in b
 	LD	c,(IX+#01)	;page number in c
 	call	m_free_b_c
@@ -1365,7 +1365,7 @@ m_priortab	db	4,1,1,5,255,1,2,1,6,4,1,1,5,1
 
 inst	db	0	;0=another virginal program
 	                        ;-->then show boot logo+src_mem
-	db	0	;don't skip srcem
+	db	0	;don't skip src_mem
 i_new	equ	inst+#00	;brand new compass 0=yes
 i_skipsrcmem	equ	inst+#01	;should the searchmem be skipped w?0=no
 i_mem_sbuf	equ	inst+#02	;sbuf,datbuf,labelbuf config

--- a/Compass129Sources/COMfile/C12COM9.ASC
+++ b/Compass129Sources/COMfile/C12COM9.ASC
@@ -1,14 +1,14 @@
 	;Compass #1.2.09 - COMfile
-	;logo-routine eventueel nog verbeteren
-	;gebaseerd op v1.1, doch volledig herschreven en herwerkt
+	;the logo routine can be improved
+	;based on v1.1, but completely rewritten and reworked
 	;25-10-98 JDS
 	;Copyright 1998 by Compjoetania The Next Generation
 
 	.label	13
 
 bdos	equ	#0005
-headln	equ	128	;lengte van de header (DATfile)
-headlncom	equ	110	;lengte van de header (COMfile)
+headln	equ	128	;length of the header (DATfile)
+headlncom	equ	110	;length of the header (COM file)
 
 kbuf	equ	#f41f
 temp_page3	equ	kbuf
@@ -46,8 +46,8 @@ J0119	ei
 	jr	c,noshift
 	ld	a,(i_limit)
 	ld	(nr_max),a
-	xor	a	;hierdoor wordt er een search mem gedaan
-	ld	(i_skipsrcmem),a	;ipv een installing memory
+	xor	a	;this will force a mem search mem
+	ld	(i_skipsrcmem),a	;instead of installing memory
 noshift	LD	A,(#FCC1)
 	LD	HL,#002D
 	CALL	#000C
@@ -57,9 +57,9 @@ noshift	LD	A,(#FCC1)
 	JP	Z,bdos
 	ld	hl,ctngcode
 	res	0,(hl)
-	LD	A,(i_new)	;logo tonen?
+	LD	A,(i_new)	;show logo?
 	OR	A
-	JR	Z,J0142	;ja,program is new
+	JR	Z,J0142	;yes, program is new
 	LD	A,(i_logo)
 	OR	A
 	JR	Z,J0145	;or logo is on
@@ -79,7 +79,7 @@ J0145:	DI
 	xor	a
 	ld	(#f3ea),a
 	ld	(#f3eb),a
-	LD	IX,#0062	;stel kleuren in
+	LD	IX,#0062	;set colors
 	LD	IY,(#FCC0)
 	CALL	#001C
 	ld	a,80
@@ -88,7 +88,7 @@ J0145:	DI
 	LD	IX,#005F
 	LD	IY,(#FCC0)
 	CALL	#001C
-;mainprogram
+;main program
 	LD	DE,txt_intro
 	CALL	print
 	CALL	fill_dosnr
@@ -112,10 +112,10 @@ J0145:	DI
 	inc	hl
 	ld	d,(hl)
 	call	print
-	ld	a,(i_skipsrcmem)	;gesavede versie zonder shiftopstart?
+	ld	a,(i_skipsrcmem)	;saved version without shiftstart?
 	or	a
-	jr	nz,meminst	;ja, direct installeren dan
-	ld	de,txt_limit	;niet gesavede versie of met shift
+	jr	nz,meminst	;yes, install immediately then
+	ld	de,txt_limit	;unsaved version or with shift
 	call	print
 	ld	hl,(nr_max)
 	call	print_memory
@@ -133,10 +133,10 @@ meminst	ld	de,txt_inst
 	jr	nc,okidoki
 	ld	de,txt_notfree
 	call	print
-	ld	a,#ae	;poke nieuwe opcode: res 5,(ix+0)
-	ld	(m_res6),a	;dit dient om de free-routine weer
-	xor	a	;gewoon te maken (was veranderd)
-	ld	(i_skipsrcmem),a	;default memuse in de datfile
+	ld	a,#ae	;poke new opcode: res 5,(ix+0)
+	ld	(m_res6),a	;this serves to display the free-routine
+	xor	a	;just to do (had changed)
+	ld	(i_skipsrcmem),a	;default memuse in the datfile
 	jr	memsrc
 okidoki	ld	de,txt_okused
 	call	print
@@ -145,44 +145,44 @@ okidoki	ld	de,txt_okused
 	ld	de,txt_load
 	call	print
 	LD	A,(#F343)	;page2 dosslot
-	LD	C,A	;in C:slotcode
+	LD	C,A	;in C:slot code
 	ld	a,(tab_TPA+2)
-	LD	B,a	;in B:bloknr
+	LD	B,a	;in B: block nr
 	CALL	ld_blokb_2c
 	LD	A,(stat_dos)
 	CP	#02
-open_dos1	LD	DE,fcb_compass	;open file (dos1) klaarzetten
+open_dos1	LD	DE,fcb_compass	;prepare open file (dos1)
 	LD	C,#0F
 	JR	C,go_load
 	LD	HL,env_program
 	LD	DE,#8000
 	LD	BC,#FF6B
-	CALL	bdos	;get env-item PROGRAM
+	CALL	bdos	;get env item PROGRAM
 	OR	A
 	scf
 	JR	NZ,open_dos1
-	LD	HL,env_compass	;vul COMPASS met de inhoud van
-	LD	DE,#8000	;het PROGRAMenv-item
+	LD	HL,env_compass	;fill COMPASS with the contents of
+	LD	DE,#8000	;the PROGRAM env item
 	LD	C,#6C
 	CALL	bdos
 	or	a
 	jp	nz,env_error
-	LD	DE,#8000	;filehandle aanmaken voor dat-file
+	LD	DE,#8000	;create filehandle for dat file
 	LD	BC,#005B
 	CALL	bdos
 	EX	DE,HL
-	LD	A,#2E	;DE wijzend op 'c' van compass
+	LD	A,#2E	;DE pointing at 'c' of compass
 	LD	(fcb_compass+8),A
 	LD	HL,fcb_compass+1
-	LD	BC,12	;kopieer ook terminating zero
-	LDIR		;vervang filename door de dat-versie
-	LD	DE,#8000	;de handle is nu klaar
+	LD	BC,12	;also copy terminating zero
+	LDIR		;replace filename with dat version
+	LD	DE,#8000	;the handle is now ready
 	XOR	A
-	LD	C,#43	;open filehandle (dos2)
+	LD	C,#43	;open file handle (dos2)
 go_load	CALL	bdos
 	OR	A
 	JP	NZ,loaderror
-	LD	A,B	;bewaar new handlenr (dos2)
+	LD	A,B	;save new handlenr (dos2)
 	LD	(new_handle),A
 	ld	de,0
 	ld	hl,headln
@@ -195,7 +195,7 @@ go_load	CALL	bdos
 
 schuifop	LD	(fcb_compass+33),HL
 	LD	(fcb_compass+35),DE
-	ld	l,1	;size op 1byte
+	ld	l,1	;size at 1 byte
 	LD	(fcb_compass+14),HL
 
 	LD	DE,#8140
@@ -204,7 +204,7 @@ schuifop	LD	(fcb_compass+33),HL
 	CALL	load_data
 	LD	BC,(compass_1)
 	CALL	slot_en_move
-	LD	HL,#0000	;vul deel 1 aan met de dosstart
+	LD	HL,#0000	;complete part 1 with the dosstart
 	LD	DE,#4000
 	LD	BC,#0140
 	LDIR
@@ -227,9 +227,9 @@ schuifop	LD	(fcb_compass+33),HL
 	LD	BC,(compass_3)
 	CALL	slot_en_move
 
-	LD	A,(stat_dos)	;file sluiten
+	LD	A,(stat_dos)	;close file
 	CP	#02
-	LD	DE,fcb_compass	;file sluiten (dos1) klaarzetten
+	LD	DE,fcb_compass	;close file (dos1) ready
 	LD	C,16
 	JR	C,go_close
 	LD	A,(new_handle)
@@ -252,34 +252,34 @@ stop_wacht2	ld	a,(#fbec)
 go_launch	ld	de,txt_launch
 	call	print
 
-	LD	HL,inst	;instellingen
+	LD	HL,inst	;institutions
 	LD	DE,kbuf
 	LD	BC,inst_end-inst
 	LDIR
-	LD	HL,work_ROMRAM	;ROM/RAMtabel naar #c000
-	LD	DE,#C000	;mem_tabel naar #c060
-	LD	BC,#60+#c1+8+4	;compass-segments naar #c121
-	LDIR		;tpasegmentnrs naar #c129
+	LD	HL,work_ROMRAM	;ROM/RAM table to #c000
+	LD	DE,#C000	;mem_table to #c060
+	LD	BC,#60+#c1+8+4	;compass segments to #c121
+	LDIR		;tpasegmentnrs to #c129
 
-	LD	BC,(compass_1)	;schakel startsegment aan op page2
+	LD	BC,(compass_1)	;turn on start segment on page2
 	CALL	ld_blokb_2c
-	ld	de,(stat_dos)	;dosversie in E,statmem in D
+	ld	de,(stat_dos)	;dosversion in E,statmem in D
 	ld	hl,inst-#0100
 	ld	bc,inst_end-inst
 	JP	#8149
 
 env_error	ld	de,txt_err_env
 	jr	free_all
-err_in_call	POP	HL	;terugsprong vernietigen
+err_in_call	POP	HL	;discard return address
 loaderror	LD	DE,txt_lderr
 free_all	call	print
 	ld	hl,ctngcode
 	set	0,(hl)
-	jp	m_freeall	;segmenten vrijgegeven
+	jp	m_freeall	;segments released
 
-;************************************************einde main,begin routines
-;vult doskernel nummer in
-;1=DOS1 2=DOS2 of hoger ;)
+;************************************************end main ,start routines
+;fill in doskernel number
+;1=DOS1 2=DOS2 or higher ;)
 fill_dosnr	LD	C,#6F
 	CALL	bdos
 	LD	A,B
@@ -290,15 +290,15 @@ fill_dosnr	LD	C,#6F
 J20F4:	LD	(stat_dos),A
 	RET
 
-;vult memorystatus in
-;0=DOS1,use own  1=DOS2 mapper support  2=Memman+DOS1 3=Memman+DOS2
+;fill in memory status
+;0=DOS1,use own 1=DOS2 mapper support 2=Memman+DOS1 3=Memman+DOS2
 fill_stat_mem	DI
 	XOR	A
 	LD	DE,#4D1E	;Memman Inichk
 	CALL	#FFCA
 	CP	#4D
 	JR	NZ,no_memman
-	ld	hl,-#0204	;test op versie 2.4
+	ld	hl,-#0204	;test for version 2.4
 	add	hl,de
 	jr	nc,old_memman
 	ld	bc,#0400
@@ -328,7 +328,7 @@ no_memman	LD	HL,#FB20
 	BIT	0,(HL)
 	LD	A,#00
 	JR	Z,J2125
-	XOR	A	;extra controle op aanwezigheid dos2map.
+	XOR	A	;extra check for presence of dos2map.
 	LD	DE,#0402
 	LD	HL,#0000
 	CALL	#FFCA
@@ -337,11 +337,11 @@ no_memman	LD	HL,#FB20
 	JR	Z,J2125
 	LD	A,B
 	LD	(primmap_slot),A
-	LD	(jp_all_seg),HL	;1e entry ALL_SEG 
+	LD	(jp_all_seg),HL	;1st entry ALL_SEG
 	INC	HL
 	INC	HL
 	INC	HL
-	LD	(jp_fre_seg),HL	;FRE_SEG 
+	LD	(jp_fre_seg),HL	;FRE_SEG
 	ld	hl,#f2c7
 	ld	de,tab_TPA
 	ld	bc,4
@@ -350,20 +350,20 @@ no_memman	LD	HL,#FB20
 J2125:	LD	(stat_mem),A
 	RET
 
-chk_ROMRAM	LD	A,(#F341)	;chk_ROMRAM ook beschikbaar in page 2
-	LD	H,#80	;(gebruikt bij het checken van page 0)
+chk_ROMRAM	LD	A,(#F341)	;chk_ROMRAM also available in page 2
+	LD	H,#80	;(used when checking page 0)
 	CALL	#0024
 	LD	A,(tab_TPA)
 	OUT	(#FE),A
 	LD	IX,work_ROMRAM
-	LD	B,3	;doe voor 3 pages: 0,1,2
-	ld	hl,0	;beginnen met page 0,ramcount op nul
-	ld	(savepage),hl	;bewaar in page 3
+	LD	B,3	;do for 3 pages: 0,1,2
+	ld	hl,0	;start with page 0,ramcount to zero
+	ld	(savepage),hl	;save to page 3
 	ld	(RAM_count),hl
 
 loop_page	PUSH	BC
 	LD	DE,#FCC1
-	LD	C,#80	;voorlopige slotcode
+	LD	C,#80	;provisional slot code
 	LD	B,4
 loop_slot	PUSH	BC
 	PUSH	DE
@@ -373,23 +373,23 @@ loop_slot	PUSH	BC
 	JR	NZ,expanded
 	RES	7,C
 	CALL	chk_notexp
-	LD	DE,#0008	;next prim.slot (en automatisch
-	ADD	IX,DE	;IX eventueel naar next page)
+	LD	DE,#0008	;next prim.slot (and automatic
+	ADD	IX,DE	;IX possibly to next page)
 	JR	J21BB
 expanded	CALL	chk_exp
-J21BB:	POP	DE	;volgend primary slot
+J21BB:	POP	DE	;next primary slot
 	POP	BC
 	INC	DE
 	INC	C
 	DJNZ	loop_slot
 	POP	BC
-	LD	HL,savepage	;volgende pagina
+	LD	HL,savepage	;next page
 	INC	(HL)
 	DJNZ	loop_page
-	LD	A,(#F343)	;herstel en ret from chk_ROMRAM
-	LD	H,#80	;merk op dat de juiste mapperpage
-	CALL	#0024	;nog niet is ingesteld voor page 2
-	LD	A,(#F342)	;evenzo voor page 1
+	LD	A,(#F343)	;restore and ret from chk_ROMRAM
+	LD	H,#80	;note that the correct mapperpage
+	CALL	#0024	;not yet set up for page 2
+	LD	A,(#F342)	;likewise for page 1
 	LD	H,#40
 	JP	#0024
 
@@ -402,14 +402,14 @@ chk_exp	LD	HL,get_memtype
 	LD	(cl_adres),HL
 	ADD	IX,DE
 	JP	#8000+go2_2
-go2_2	LD	B,4	;doe voor ieder subslot
+go2_2	LD	B,4	;do for each subslot
 J21F5:	PUSH	BC
 	db	#cd	;call
 cl_adres	dw	0
 	INC	IX	;next subslot
 	INC	IX
 	POP	BC
-	INC	C	;pas de slotcode aan
+	INC	C	;change the slot code
 	INC	C
 	INC	C
 	INC	C
@@ -417,12 +417,12 @@ cl_adres	dw	0
 	LD	A,(savepage)
 	OR	A
 	RET	NZ
-fix_page0	LD	A,(#F341)	;herstel slotinstelling page 0
+fix_page0	LD	A,(#F341)	;restore slot setting page 0
 	CALL	#8000+set_slot_p0
-	LD	A,(#8000+tab_TPA)	;en ook page
+	LD	A,(#8000+tab_TPA)	;and also page
 	OUT	(#FC),A
-	ld	de,#8000	;merk op: -#8000 =#8000
-	add	ix,de	;#8000 AFTREKKEN van IX
+	ld	de,#8000	;note: -#8000 =#8000
+	add	ix,de	;#8000 SUBSTRACT from IX
 	RET
 
 chk_notexp	OR	A
@@ -433,9 +433,9 @@ go2_1	LD	DE,#8000
 	CALL	#8000+get_memtype
 	JR	fix_page0
 
-get_memtype	LD	A,(IX+#00)	;werd er hier reeds een mapper
-	OR	A	;gemeld?
-	RET	NZ	;ja, niet testen dan
+get_memtype	LD	A,(IX+#00)	;was there already a mapper here
+	OR	A	;reported?
+	RET	NZ	;yes, don't test then
 	LD	A,(savepage)
 	OR	A
 	JR	Z,chk_0
@@ -452,8 +452,8 @@ J225B:	PUSH	HL
 	LD	A,C
 	CALL	#0024
 	POP	HL
-;in: IX(pointer naar 2bytes),HL(adres in de page),pagenr op savepage
-Ram_of_Rom	LD	A,(HL)	;test op Ram
+;in: IX(pointer to 2bytes),HL(address in the page),pagenr on savepage
+Ram_of_Rom	LD	A,(HL)	;test for Ram
 	ld	b,a
 	INC	(HL)
 	inc	a
@@ -465,8 +465,8 @@ Ram_of_Rom	LD	A,(HL)	;test op Ram
 	add	a,#fc
 	ld	c,a
 	LD	B,#00
-J2292:	OUT	(C),B	;zet op ieder ramblok byte hl op 0
-	LD	A,(HL)	;volgorde: 0,255,254,253,...
+J2292:	OUT	(C),B	;set byte hl to 0 on every ram block
+	LD	A,(HL)	;order: 0,255,254,253,...
 	LD	(HL),0
 	PUSH	AF
 	DJNZ	J2292
@@ -475,15 +475,15 @@ J2292:	OUT	(C),B	;zet op ieder ramblok byte hl op 0
 J229D:	OUT	(C),D
 	LD	A,(HL)
 	OR	A
-	JR	NZ,J22A7	;ramblok 1 voor 2e keer geschakeld?
+	JR	NZ,J22A7	;ram block 1 switched for the second time?
 	LD	(HL),D
 	INC	D
 	DJNZ	J229D
-J22A7:	dec	d	;trek er dus 2 van af
+J22A7:	dec	d	;then subtract 2 from it
 	dec	d
-	LD	(IX+#01),D	;bewaar maxnr voor mapperram
-	jr	z,vast_ram	;bij vast ram is maxnr=0
-	LD	(IX+#20),2	;zet ramcode voor page 1en2
+	LD	(IX+#01),D	;save maxnr for mapperram
+	jr	z,vast_ram	;with fixed ram maxnr=0
+	LD	(IX+#20),2	;put ramcode for page 1and2
 	LD	(IX+#40),2
 	LD	(IX+#21),D
 	LD	(IX+#41),D
@@ -512,25 +512,25 @@ telop1	xor	(hl)
 	djnz	telop1
 	pop	hl
 	ld	c,a
-	or	a	;allemaal #ff
+	or	a	;all of them #ff
 	ret	z
 	ld	b,15
 	ld	a,e
 telop2	xor	(hl)
 	add	hl,de
 	djnz	telop2
-	cp	c	;als de 2 checksums niet hetzelfde zijn,
-	ret	nz	;dan was er een leesfout en dus geen rom
-	inc	(ix)	;wel echt rom
+	cp	c	;if the 2 checksums are not the same,
+	ret	nz	;then there was a reading error and therefore no rom
+	inc	(ix)	;really rom
 	RET
 
-;routine (in page 2) die slot A inschakelt op page 0
+;routine (in page 2) that switches slot A on page 0
 set_slot_p0	ld	b,a
 	bit	7,a
 	jr	nz,set_exp	;expanded slot?
-	IN	A,(#A8)	;nee, gewoon zetten
+	IN	A,(#A8)	;no, just switch it
 	AND	#fc
-	OR	B	;merk op:bit 2-6 zijn 0 voor notexp.slot
+	OR	B	;note: bits 2-6 are 0 for notexp.slot
 	OUT	(#A8),A
 	RET
 set_exp	rrca
@@ -539,7 +539,7 @@ set_exp	rrca
 	and	#c0
 	ld	h,a
 	in	a,(#a8)
-	ld	e,a	;oude a8-stand bewaren in e
+	ld	e,a	;save old a8 status in e
 	and	#3f
 	or	h
 	out	(#a8),a
@@ -551,9 +551,9 @@ set_exp	rrca
 	and	#fc
 	or	l
 	ld	(#ffff),a
-	ld	d,a	;nieuwe ffff-stand in d
+	ld	d,a	;new ffff-stand in d
 	ld	a,e
-	out	(#a8),a	;page 3 herstellen
+	out	(#a8),a	;restore page 3
 	ld	hl,#fcc5
 	ld	a,b
 	and	#03
@@ -593,16 +593,16 @@ oksub	djnz	divide
 
 get_used	ld	ix,mem_tabel
 	ld	de,#2e
-	ld	a,4	;vier voor compassblocks
-	ld	b,4	;doe voor de 4 buffers
-sommeer	add	a,(ix)	;tel aantal sbuffersegmenten erbij
-	add	a,(ix+#21)	;tel aantal databuffersegmenten erbij
-	add	ix,de	;naar volgende buffer
+	ld	a,4	;four for compass blocks
+	ld	b,4	;do for the 4 buffers
+sommeer	add	a,(ix)	;add number of sbuffer segments
+	add	a,(ix+#21)	;add number of data buffer segments
+	add	ix,de	;to next buffer
 	djnz	sommeer
-	add	a,(ix)	;tel aantal labelbuffersegmenten erbij
+	add	a,(ix)	;add number of label buffer segments
 	ld	l,a
 	ld	h,0
-;invoer: hl=aantal segmenten, print 'a segments (xxxxkB RAM)',13,10
+;input: hl=number of segments, print 'a segments (xxxxkB RAM)',13,10
 print_memory	push	hl
 	call	print_dec
 	ld	de,txt_segments
@@ -617,83 +617,83 @@ print_memory	push	hl
 print	LD	C,#09
 	JP	bdos
 
-;***************************************************memoryroutines
-;LET OP: er is een verschil tussen een tpa-segment en een tpaslot-segment
-;tpa-segment is dus (in veel gevallen) ramblok 0,1,2 of 3 van de primary mapper
-;tpaslot_segment kan elk ramblok van de primarymapper zijn
+;*****************************************************memory routines
+;NOTE: there is a difference between a tpa segment and a tpaslot segment
+;tpa-segment is thus (in many cases) ramblock 0,1,2 or 3 of the primary mapper
+;tpaslot_segment can be any primarymapper ram block
 
-src_mem	CALL	m_tabel	;maak tabel aan met segmenten
-	ret	c	;geen enkel tpaslotsegm gevonden
-	call	m_count_free	;als je nu geen 4 segmenten hebt, moet je
-	ld	hl,3	;er niet aan beginnen! De compassblocks
-	call	m_vgl_HLDE	;mogen immers niet in tpa-segmenten
-	jp	nc,m_freeall	;zitten, dus geen m_add_321 toepasbaar
+src_mem	CALL	m_tabel	;create table with segments
+	ret	c	;no tpaslotsegm found
+	call	m_count_free	;if you don't have 4 segments,
+	ld	hl,3	;don't start it! The compass blocks
+	call	m_vgl_HLDE	;after all, are not allowed in tpa segments
+	jp	nc,m_freeall	;sitting, so no m_add_321 applicable
 	LD	DE,buffer
-	LD	HL,compass_1	;vraag tpaslotsegm aan voor cblock 1
-	CALL	m_src_dosram	;gaat altijd, we hadden er immers 1
-	LD	DE,buffer	;de volgende 3 segmenten zijn steeds
-	ld	hl,compass_0	;te vinden want we hadden vier segm.
-	CALL	m_use_zet6_hl	;zoek voor compass blok 0
-	inc	hl	;sla compassblok 1 over
+	LD	HL,compass_1	;request tpaslotsegm for cblock 1
+	CALL	m_src_dosram	;always works, after all we had 1
+	LD	DE,buffer	;the next 3 segments are always
+	ld	hl,compass_0	;because we had four segm.
+	CALL	m_use_zet6_hl	;search for compass block 0
+	inc	hl	;skip compass block 1
 	inc	hl
-	CALL	m_use_zet6_hl	;zoek voor compassblok 2
-	CALL	m_use_zet6_hl	;zoek voor compassblok 3
+	CALL	m_use_zet6_hl	;search for compass block 2
+	CALL	m_use_zet6_hl	;search for compass block 3
 
-	CALL	m_count_free	;tel het aantal ongebruikte blokken
-	LD	IX,buffer	;selecteer eerste labelblok
-	LD	BC,#0109	;dit moet ook in het tpaslot zitten
+	CALL	m_count_free	;count the number of unused blocks
+	LD	IX,buffer	;select first label block
+	LD	BC,#0109	;this should also be in the tpaslot
 	CALL	m_usepages
 	jr	nc,m_okee
-	call	m_add_321	;mislukt, voeg tpa-segs toe
-	call	m_count_free	;nu moet het gaan
+	call	m_add_321	;failed, add tpa segs
+	call	m_count_free	;now it must work
 	ld	ix,buffer
 	ld	bc,#0109
 	call	m_usepages
-	jp	c,m_freeall	;eigenlijk niet nodig
+	jp	c,m_freeall	;actually not necessary
 
-m_okee	call	m_count_free	;als je hier komt zijn er nog zeker 2
-	ld	hl,1	;tpasegm over. Gebruik deze als je geen
-	call	m_vgl_HLDE	;2 andere meer hebt voor sbuf1+data1
+m_okee	call	m_count_free	;when you come here there are at least 2 more
+	ld	hl,1	;tpasegm left. Use this if you run out of
+	call	m_vgl_HLDE	;2 more for sbuf1+data1
 	call	nc,m_add_321
 
-	LD	IX,buffer	;selecteer vervolgens 1 sourcebufblok
+	LD	IX,buffer	;then select 1 sourcebufblock
 	LD	BC,#0101
-	CALL	m_usepages	;gaat dus altijd
+	CALL	m_usepages	;always works
 
-	LD	BC,#0105	;selecteer 1 datablok bij sbuf 1
-	CALL	m_usepages	;gaat dus altijd
+	LD	BC,#0105	;select 1 data block at sbuf 1
+	CALL	m_usepages	;always works
 
-	LD	IY,m_priortab	;vul eventueel nog wat verder aan
+	LD	IY,m_priortab	;add more if needed
 J23BC:	LD	A,(IY+#00)
 	INC	IY
 	OR	A
-	JR	Z,J23DE	;einde priortab; geen enkel goei
-	CP	#FF	;configuratie meer gevonden
-	JR	Z,J23D5	;check of er nog 2 zijn
-	LD	B,A	;get aantal
+	JR	Z,J23DE	;end of priority tab; no good
+	CP	#FF	;configuration found anymore,
+	JR	Z,J23D5	;check if there are 2 more
+	LD	B,A	;get number
 	LD	C,(IY+#00)	;get type
 	INC	IY
-	CALL	m_usepages	;zet in use
-	JR	C,J23DE	;blijkt onmogelijk, stop dan maar
-	JR	J23BC	;okee
-J23D5:	LD	A,D	;zijn er nog 2 segmenten over?
+	CALL	m_usepages	;put in use
+	JR	C,J23DE	;it's not possible, then stop
+	JR	J23BC	;okay
+J23D5:	LD	A,D	;are there 2 segments left?
 	OR	A
-	JR	NZ,J23BC	;zo ja,probeer er nog te usen
+	JR	NZ,J23BC	;if so, try to use them
 	LD	A,E
 	CP	#02
 	JR	NC,J23BC
-J23DE:	CALL	m_free	;free wat niet gebruikt werd
+J23DE:	CALL	m_free	;free what was not used
 	XOR	A
 	RET
 
 m_tabel	ld	hl,(nr_max)
-	LD	A,(stat_mem)	;zoek tot je zeker 2 segm in het tpaslot
-	OR	A	;hebt en tot je minstens nr_max segm hebt
-	JP	NZ,m_manage	;of zoek tot geheugen op is
+	LD	A,(stat_mem)	;search until you find at least 2 segm in the tpaslot
+	OR	A	;and until you have at least nr_max segm
+	JP	NZ,m_manage	;or search until memory runs out
 	push	hl
-	ld	ix,tempbuffer	;gebruik de hoogste 2 segmenten van de
-	ld	a,(#f344)	;mainmapper als 2 tpaslot-segmenten
-	ld	(ix),a	;bewaar 1e slotcode
+	ld	ix,tempbuffer	;use the top 2 segments of the
+	ld	a,(#f344)	;mainmapper as 2 tpaslot segments
+	ld	(ix),a	;save 1st slot code
 	ld	b,a
 	and	#03
 	rlca
@@ -711,90 +711,90 @@ m_tabel	ld	hl,(nr_max)
 	ld	a,(hl)	;get maxblocknr primary mapper
 	pop	hl
 	dec	hl
-	cp	4	;test of de mapper >64kB
+	cp	4	;test if the mapper is >64kB
 	ret	c
-	ld	(ix+1),a	;bewaar 1e segmnr
-	jr	z,go_on	;2e tpasegment zou anders nr 3 zijn
-	;                        ;dit moet nu nog niet toegevoegd worden
-	ld	(ix+2),b	;bewaar 2e slot
+	ld	(ix+1),a	;save 1st segment num
+	jr	z,go_on	;2nd tpa segment would otherwise be number 3
+	;                           ;this should not be added yet
+	ld	(ix+2),b	;save 2nd slot
 	dec	a
-	ld	(ix+3),a	;bewaar 2e segmnr
+	ld	(ix+3),a	;save 2nd segment num
 	dec	hl
 go_on	ld	ix,buffer
-	ld	de,work_ROMRAM+#41	;waarom voor page2?*******
-	LD	IY,#FCC1	;-->'t is eigenlijk al 't zelfde
-	LD	BC,#1000	;16=ga de 16 subslots af, C=def.slot
+	ld	de,work_ROMRAM+#41	;why for page2?*******
+	LD	IY,#FCC1	;--> it's actually the same
+	LD	BC,#1000	;16=go through the 16 subslots, C=def.slot
 J256B:	PUSH	BC
 	PUSH	DE
-	BIT	7,(IY+#00)	;is het in een uitgebreid slot?
+	BIT	7,(IY+#00)	;is it in an extended slot?
 	JR	Z,in_not_exp
-	SET	7,C	;pas de slotcode aan
-in_not_exp	ld	a,(#f344)	;sla het tpa-slot over
+	SET	7,C	;change the slot code
+in_not_exp	ld	a,(#f344)	;skip the tpa slot
 	cp	c
 	jr	z,volgend
-	call	m_scanslot	;input: C=slotcode DE=adres met maxsegnr
+	call	m_scanslot	;input: C=slot code DE=address with maxsegnr
 	jr	c,found_genoeg
 volgend	POP	DE
 	POP	BC
 	INC	DE
 	INC	DE
-	LD	A,C	;pas de slotcode aan
+	LD	A,C	;change the slot code
 	AND	#0C
-	CP	#0C	;was het een subslot 3?
+	CP	#0C	;was it a subslot 3?
 	LD	A,C
-	LD	C,#04	;neen, gewoon 1 subslot bijtellen
+	LD	C,#04	;no, just add 1 subslot
 	JR	NZ,J25B2
-	INC	IY	;ja, next primary slot IY
-	LD	C,%11110101	;next prim slot,sec.slot op nul,bit7=0
+	INC	IY	;yes, next primary slot IY
+	LD	C,%11110101	;next prim slot,sec.slot to zero,bit7=0
 J25B2:	ADD	A,C
 	LD	C,A
 	DJNZ	J256B
-	call	m_add_temp	;voeg 2of1 eerder gevonden tpa tussen
+	call	m_add_temp	;insert 2or1 previously found tpa
 	ld	a,(#f344)
 	ld	c,a
-	ld	de,tempbuffer+1	;adres waar maxpagenr staat
-	ld	a,(de)	;hou rekening dat de hoogste nrs
-	dec	a	;reeds de deur uit zijn
-	dec	a	;zelfs al is er maar 1 weg, dan vallen
-	ld	(de),a	;de segmenten toch in het tpagebied
-	call	m_scanslot	;voeg de tpaslotsegs als laatste toe
-	LD	(IX+#00),#00	;terminating nulslotcode
-	or	a	;wis carry
+	ld	de,tempbuffer+1	;address where maxpagenr is
+	ld	a,(de)	;take into account that the highest nums
+	dec	a	;are already out of the door
+	dec	a	;even if only 1 is gone, then fall
+	ld	(de),a	;the segments in the tpa area anyway
+	call	m_scanslot	;add the tpaslotsegs last
+	LD	(IX+#00),#00	;terminating zero slot code
+	or	a	;clear carry
 	ret
-found_genoeg	pop	de	;stack schoonmaken
+found_genoeg	pop	de	;stack cleanup
 	pop	bc
-	call	m_add_temp	;add 2of1 eerder gevonden tpa
-	LD	(IX+#00),#00	;terminating nulslotcode
-	or	a	;wis carry
+	call	m_add_temp	;add 2or1 previously found tpa
+	LD	(IX+#00),#00	;terminating zero slot code
+	or	a	;clear carry
 	ret
 
 m_scanslot	LD	A,(DE)
-	or	a	;mapperram hier?
-	ret	Z	;nee, (rom of vast ram)
-	LD	A,(#F344)	;zitten we in het DOSRAM?
+	or	a	;mapperram here?
+	ret	Z	;no, (rom or fixed ram)
+	LD	A,(#F344)	;are we in the DOSRAM?
 	CP	C
-	ld	a,(de)	;laadt maxpagenr op vooraleer DE
-	ld	e,0	;wordt gebruikt
+	ld	a,(de)	;loads maxpagenr before DE
+	ld	e,0	;is used
 	ld	d,a
 	ld	b,a
-	JR	NZ,J2589	;nee, alles registreren
-	inc	e	;e op 1
-J2589	inc	b	;effectief aantal blokken
+	JR	NZ,J2589	;no, register everything
+	inc	e	;e on 1
+J2589	inc	b	;effective number of blocks
 J258B	LD	A,H
 	OR	L
 	scf
-	ret	Z	;we hebben er al genoeg (nr_max blokken!)
-	bit	0,e	;zitten we in het tpa-slot?
-	jr	z,m_do_reg	;nee, registreer dan direct
+	ret	Z	;we already have enough (nr_max blocks!)
+	bit	0,e	;are we in the tpa slot?
+	jr	z,m_do_reg	;no, register immediately
 	ld	a,d
 	push	hl
-	call	m_chk_tpa	;is het een tpasegment?
+	call	m_chk_tpa	;is it a tpa segment?
 	pop	hl
-	jr	z,m_do_skip	;ja,niet registreren dan
-m_do_reg	DEC	HL	;zoek 1 page minder
-	LD	(IX+#00),C	;bewaar slotcode
+	jr	z,m_do_skip	;yes, don't register then
+m_do_reg	DEC	HL	;search 1 page less
+	LD	(IX+#00),C	;save slot code
 	INC	IX
-	LD	(IX+#00),D	;bewaar rambloknr
+	LD	(IX+#00),D	;save ram block number
 	INC	IX
 m_do_skip	dec	d
 	djnz	J258B
@@ -814,35 +814,35 @@ m_chk_tpa	ld	hl,tab_TPA	;check for page 0
 	ret
 
 m_manage	ld	ix,tempbuffer
-	call	m_alloc_tpa	;alloceer 2 tpaslotsegm. naar tempbuffer
+	call	m_alloc_tpa	;allocate 2 tpaslotsegm. to temp buffer
 	ret	c
 	call	m_alloc_tpa
-	;de eerste dient voor cblock1
-	;de tweede mag ontbreken, deze dient voor de labelbuffer
-	;als hij ontbreekt, wordt hij later in de maintpa-segm. gezet
-	;Merk op: de laatste 2 bytes van tempbuffer zullen dan 0 zijn
-	;hier wordt rekening mee gehouden bij m_add_temp
-	ld	ix,buffer	;merkop:2 tpa gevonden,dan ix al goed
+	;the first is for cblock1
+	;the second may be missing, it is for the label buffer
+	;if it's missing it'll be in the maintpa segm later. set
+	;Note: the last 2 bytes of tempbuffer will then be 0
+	;this is taken into account in m_add_temp
+	ld	ix,buffer	;note: 2 tpa found, then ix already good
 m_all_notpa	call	m_alloc_notpa
-	JR	C,m_outofnottpa	;niet-tpa segmenten zijn op
+	JR	C,m_outofnottpa	;we're out of non-tpa segments
 	LD	A,H
 	OR	L
 	JR	NZ,m_all_notpa
-	call	m_add_temp	;voeg de twee tpaslotsegs toe
+	call	m_add_temp	;add the two tpaslotsegs
 	ld	(ix),0
-	or	a	;wis carry
+	or	a	;clear carry
 	ret
-m_outofnottpa	call	m_add_temp	;voeg de twee tpaslotsegs in
+m_outofnottpa	call	m_add_temp	;insert the two tpaslotsegs
 m_all_tpa	call	m_alloc_tpa
-	JR	C,m_outoftpa	;niet-tpa segmenten zijn op
+	JR	C,m_outoftpa	;we're out of non-tpa segments
 	LD	A,H
 	OR	L
 	JR	NZ,m_all_tpa
 m_outoftpa	ld	(ix),0
-	or	a	;wis carry
+	or	a	;clear carry
 	ret
 
-m_add_temp	push	hl	;voeg de 1 of 2 segmenten in
+m_add_temp	push	hl	;insert the 1 or 2 segments
 	ld	hl,tempbuffer
 	push	ix
 	pop	de
@@ -851,17 +851,17 @@ m_add_temp	push	hl	;voeg de 1 of 2 segmenten in
 	xor	a
 	cp	(hl)
 	jr	z,m_skip_2
-	ldi		;voeg ook 2e in
+	ldi		;also add 2nd
 	ldi
 m_skip_2	push	de
 	pop	ix
 	pop	hl
 	ret
-m_alloc_tpa	ld	bc,#4300	;memman:prefereer tpa dos2:tpa only
+m_alloc_tpa	ld	bc,#4300	;memman:prefer tpa dos2:tpa only
 	call	m_all_save
-	ret	c	;abort, geen tpa meer
-	ld	a,(#f344)	;controle op memman: was het wel een tpa
-	cp	b	;dos geeft wel steeds tpa
+	ret	c	;abort, no more tpa
+	ld	a,(#f344)	;check on memman: was it a tpa
+	cp	b	;dos always gives tpa
 	ret	z
 m_free_it	inc	hl
 	dec	ix
@@ -876,38 +876,38 @@ m_free_it	inc	hl
 
 m_alloc_notpa	ld	a,(stat_mem)
 	cp	2
-	jr	nc,m_alloc_mntpa	;iets moeilijker bij memman
-	ld	c,#10	;dos2:zeker geen tpa
+	jr	nc,m_alloc_mntpa	;a little more difficult with memman
+	ld	c,#10	;dos2:definitely no tpa
 	jr	m_all_save	;=call m_all_save, ret
 m_alloc_mntpa	ld	b,0
 m_try_nottpa	push	bc
 	ld	b,#03	;memman:fseg
 	call	m_all_save
 	jr	c,m_alles_op
-	ld	a,(#f344)	;controle op memman: was het wel een
-	cp	b	;niet-tpa?
+	ld	a,(#f344)	;check on memman: was it a
+	cp	b	;non-tpa?
 	jr	nz,m_ja_eindelyk
 	pop	bc
 	djnz	m_try_nottpa
 	di
-	halt		;hier wordt er normaal nooit gekomen, bij memman kunnen
-	;er nooit 256 tpasegm worden aangevraagd aangezien een mapper
-	;maar 256 segm telt en 0 nooit vrijgegeven wordt.
-m_ja_eindelyk	pop	bc	;haal b
+	halt		;Normally we'll never reach this, could with memman
+	;256 tpasegm are never requested since a mapper
+	;counts only 256 segments and 0 is never freed.
+m_ja_eindelyk	pop	bc	;get b
 	dec	ix
-	push	ix	;(bewaar deze plek)
+	push	ix	;(save this place)
 	dec	ix
 	call	m_free_tpa
-	pop	bc	;haal die plek waar het niettpa stond
-	ld	a,(bc)	;haal segmentnr
+	pop	bc	;get that place where it didn't stand
+	ld	a,(bc)	;get segment num
 	ld	e,a
 	dec	bc
-	ld	a,(bc)	;haal slotcode
+	ld	a,(bc)	;get slot code
 	ld	(ix),a
 	inc	ix
 	ld	(ix),e
 	inc	ix
-	or	a	;wis carry
+	or	a	;clear carry
 	ret
 m_alles_op	pop	bc
 	call	m_free_tpa
@@ -926,20 +926,20 @@ m_all_save	push	hl
 	call	Mm_dos2_alloc
 	pop	hl
 	ret	c
-	LD	(IX+#00),B	;bewaar slotcode
+	LD	(IX+#00),B	;save slot code
 	INC	IX
-	LD	(IX+#00),A	;bewaar rambloknr
+	LD	(IX+#00),A	;save ram block number
 	INC	IX
 	dec	hl
 	ret
 Mm_dos2_alloc	LD	A,(stat_mem)
 	DEC	A
 	JR	NZ,m_Mm_alloc
-	LD	A,(primmap_slot)	;enkel dos 2
+	LD	A,(primmap_slot)	;only dos 2
 	OR	C	;try to allocate segments
 	LD	B,A
-	LD	A,#01	;allocate systemsegmenten
-	db	#c3	;Jump
+	LD	A,#01	;allocate system segments
+	db	#c3	;jump
 jp_all_seg	dw	0
 m_Mm_alloc	PUSH	IX
 	LD	DE,#4D0A
@@ -947,18 +947,18 @@ m_Mm_alloc	PUSH	IX
 	POP	IX
 	LD	A,H
 	OR	L
-	SCF		;hl=0000 =segmenten zijn op
+	SCF		;hl=0000 =segments are up
 	RET	Z
-	LD	B,L	;Memmansegmentcode blijkt te bestaan uit
-	LD	A,H	;H=mapperblok L=slotcode
+	LD	B,L	;Memman segment code appears to consist of
+	LD	A,H	;H=mapperblock L=lock code
 	CCF
 	RET
 
 m_count_free	LD	HL,buffer
-	LD	DE,#0000	;aantal slotcodes met bit6 laag=unused
+	LD	DE,#0000	;count of slot codes with bit6 low=unused
 J2608:	LD	A,(HL)
 	OR	A
-	RET	Z	;einde van de lijst
+	RET	Z	;end of the list
 	BIT	6,(HL)
 	JR	NZ,J2610
 	INC	DE
@@ -973,27 +973,27 @@ m_vgl_HLDE	LD	A,H
 	SUB	E
 	RET
 
-m_freeall	ld	a,#b6	;poke nieuwe opcode: res 6,(ix+0)
-	ld	(m_res6),a	;hierdoor worden ook de gebruikte
+m_freeall	ld	a,#b6	;poke new opcode: res 6,(ix+0)
+	ld	(m_res6),a	;as a result, the used
 m_free	LD	A,(stat_mem)
 	OR	A
 	scf
-	RET	Z	;enkel als er een memmanager is
+	RET	Z	;only if there is a mem manager
 	LD	IX,buffer-2
 m_freenext	INC	IX
 	INC	IX
-	db	#DD,#CB,0	;res 5,(ix+0):dit doet dus niets
-m_res6	db	#AE	;om ALLES te free-en: poke hier #B6
-	LD	A,(IX+#00)	;dit is opcode voor res 6,(ix+0)
+	db	#DD,#CB,0	;res 5,(ix+0): so this does nothing
+m_res6	db	#AE	;to free-en EVERYTHING: poke here #B6
+	LD	A,(IX+#00)	;this is opcode for res 6,(ix+0)
 	OR	A
 	scf
-	RET	Z	;gedaan
-	bit	4,a	;is het een tpasegment?
-	jr	nz,m_freenext	;ja, niet vrijgeven dan
-	BIT	6,A	;segmenten in use niet vrijgeven en ze
-	JR	NZ,m_bit6seg	;onder memman de reserved status geven
-	ld	b,a	;slotcode in b
-	LD	c,(IX+#01)	;pagenr in c
+	RET	Z	;done
+	bit	4,a	;is it a tpa segment?
+	jr	nz,m_freenext	;yes, don't free it then
+	BIT	6,A	;do not free segments in use and they
+	JR	NZ,m_bit6seg	;give the reserved status under memman
+	ld	b,a	;slot code in b
+	LD	c,(IX+#01)	;page number in c
 	call	m_free_b_c
 	jr	m_freenext
 
@@ -1001,9 +1001,9 @@ m_bit6seg	LD	A,(stat_mem)
 	CP	#02	;memman?
 	jr	c,m_freenext
 	LD	L,(IX+#00)
-	RES	6,L	;herstel de originele slotcode
-	LD	H,(IX+#01)	;(zonder bit 6 hoog)
-	LD	DE,#4D0B	;geef reserved status (memman only)
+	RES	6,L	;restore the original slot code
+	LD	H,(IX+#01)	;(without bit 6 set)
+	LD	DE,#4D0B	;give reserved status (memman only)
 	PUSH	IX
 	CALL	#FFCA
 	pop	ix
@@ -1013,9 +1013,9 @@ m_free_b_c	LD	A,(stat_mem)
 	CP	#02
 	JR	nc,m_fre_Mm
 	ld	a,c
-	db	#c3	;jump: free onder dos2
+	db	#c3	;jump: free under dos2
 jp_fre_seg	dw	0
-m_fre_Mm	LD	L,B	;free onder memman
+m_fre_Mm	LD	L,B	;free under memman
 	LD	H,C
 	LD	DE,#4D14
 	PUSH	IX
@@ -1028,11 +1028,11 @@ J24AE:	INC	DE
 m_use_zet6_hl	LD	A,(DE)
 	BIT	6,A	;already used?
 	JR	NZ,J24AE
-	and	#8f	;wis een eventueel tpa-bit
+	and	#8f	;clear any tpa bit
 m_dosram_fnd	LD	(HL),A
 	INC	HL
-	ld	a,(de)	;haal origineel (met eventueel bit4 hoog)
-	OR	#40	;zet bit 6
+	ld	a,(de)	;get original (with possibly bit4 high)
+	OR	#40	;put bit 6
 	LD	(DE),A
 	INC	DE
 	LD	A,(DE)
@@ -1045,12 +1045,12 @@ m_dosram_fnd	LD	(HL),A
 m_src_dosram	LD	A,(#F344)
 	LD	B,A
 J249F:	LD	A,(DE)
-	OR	A	;einde al bereikt?
+	OR	A	;end already reached?
 	SCF
 	RET	Z
-	BIT	6,A	;al in special use?
+	BIT	6,A	;already in special use?
 	JR	NZ,J24AA
-	and	#8f	;wis een eventueel tpa-bit
+	and	#8f	;clear any tpa bit
 	CP	B
 	JR	Z,m_dosram_fnd
 J24AA:	INC	DE
@@ -1066,10 +1066,10 @@ J2462:	PUSH	BC
 	LD	A,(hl)
 	inc	hl
 	LD	B,C
-	CALL	m_src_b_a	;zit dit segment al in onze tabel?
-	JR	NC,J2478	;dosrampage werd gevonden
-	set	4,b	;bit zetten als teken van tpa-segment
-	LD	(IX+#00),B	;niet gevonden, voeg ze zelf toe
+	CALL	m_src_b_a	;is this segment already in our table?
+	JR	NC,J2478	;dosrampage was found
+	set	4,b	;set bit as sign of tpa segment
+	LD	(IX+#00),B	;not found, add them by ourselves
 	INC	IX
 	LD	(IX+#00),C
 	INC	IX
@@ -1079,17 +1079,17 @@ J2478:	POP	BC
 	pop	hl
 	RET
 
-m_src_b_a	LD	C,A	;zoek naar een page in slot B, nr A
-	LD	IX,buffer-2	;deze page mag eventueel gebruikt zijn
-	;uit: Not Carry: ok, IX
-	;     Carry set: not found, ix op de nulbyte
+m_src_b_a	LD	C,A	;look for a page in slot B, nr A
+	LD	IX,buffer-2	;this page may be used
+	;off: Not Carry: ok, IX
+	;Carry set: not found, ix on the zero byte
 J2485	INC	IX
 	INC	IX
 	LD	A,(IX+#00)
 	OR	A
 	SCF
 	RET	Z
-	AND	#8f	;laat bit 6 en 4 niet doorkomen
+	AND	#8f	;don't let bits 6 and 4 come through
 	CP	B
 	JR	NZ,J2485
 	LD	A,(IX+#01)
@@ -1100,14 +1100,14 @@ J2485	INC	IX
 m_usepages	PUSH	DE
 	LD	HL,mem_tabel
 	LD	A,C
-	CP	#05	;sourcebuffertype? (1-4)
-	JR	NC,m_no_sbuf	;nee
+	CP	#05	;source buffer type? (1-4)
+	JR	NC,m_no_sbuf	;new
 	LD	DE,#002E
-J23F7:	DEC	a	;zet hl goed afhankelijk van sbufnr
+J23F7:	DEC	a	;set hl correctly depending on sbufnr
 	JR	Z,m_setuse
 	ADD	HL,DE
 	JR	J23F7
-m_no_sbuf	CP	#09	;databloktype?
+m_no_sbuf	CP	#09	;data block type?
 	JR	Z,m_datablok
 	LD	DE,#0021
 	ADD	HL,DE
@@ -1120,30 +1120,30 @@ J240A:	DEC	A
 m_datablok	LD	DE,#00B8
 	ADD	HL,DE
 
-m_setuse	POP	DE	;set B vrije pages op entry hl in use
-	DEC	IX	;DE(vrije pages) wordt verlaagd
-	DEC	IX	;bit 6 wordt op hoog gezet
+m_setuse	POP	DE	;set B free pages on entry hl in use
+	DEC	IX	;DE(free pages) is reduced
+	DEC	IX	;bit 6 is set to high
 m_nxtblok	INC	IX
 	INC	IX
 	LD	A,(IX+#00)
 	OR	A
 	SCF
 	RET	Z
-	BIT	6,A	;al gebruikt voor compass?
+	BIT	6,A	;already used for compass?
 	JR	NZ,m_nxtblok
 	LD	A,C
 	CP	#09
-	JR	NZ,m_register	;registreren, when not for labelsegment
+	JR	NZ,m_register	;register, when not for labelsegment
 	LD	A,(HL)
-	OR	A	;in geval van een labelsegment mag je ook
-	JR	NZ,m_register	;registreren als het het eerste niet is
+	OR	A	;in case of a label segment we may also
+	JR	NZ,m_register	;register if it's not the first one
 	ld	a,(ix)
-	and	#8f	;eventueel bit 4 resetten (tpa-seg)
-	exx		;bewaar c
-	ld	c,a	;een eerste labelsegm. moet in het
-	ld	a,(#f344)	;tpaslot zitten
+	and	#8f	;possibly reset bit 4 (tpa-seg)
+	exx		;save c
+	ld	c,a	;a first label segment. must be in the
+	ld	a,(#f344)	;tpaslot
 	cp	c
-	exx		;herstel c
+	exx		;restore c
 	jr	nz,m_nxtblok
 m_register	PUSH	BC
 	PUSH	DE
@@ -1156,7 +1156,7 @@ m_register	PUSH	BC
 	ADD	HL,DE
 	LD	A,(IX+#00)
 	SET	6,(IX+#00)
-	and	#8f	;wis eventueel tpa-bit
+	and	#8f	;clear any tpa-bit
 	LD	(HL),A
 	INC	HL
 	LD	A,(IX+#01)
@@ -1166,38 +1166,38 @@ m_register	PUSH	BC
 	DEC	DE
 	POP	BC
 	DJNZ	m_nxtblok
-	OR	A	;succes
+	OR	A	;success
 	RET
 
-inst_mem	ld	a,(i_cblocks+2)	;controle of het tpaslot hetzelfde is
+inst_mem	ld	a,(i_cblocks+2)	;check if the tpaslot is the same
 	ld	b,a
 	ld	a,(#f344)
 	cp	b
 	scf
 	ret	nz
 	CALL	m_tabel
-	ret	c	;geen 2 tpa-segs gevonden
+	ret	c	;no 2 tpa segs found
 	CALL	m_add_321
 
-	LD	B,#04	;installeer 4 sbuffers
+	LD	B,#04	;install 4 buffers
 	LD	IY,i_mem_sbuf
 	LD	DE,#002E
 	CALL	m_chk_alloc
 	JP	C,m_freeall
 
-	LD	B,#04	;installeer 4 databuffers
+	LD	B,#04	;install 4 data buffers
 	LD	IY,i_mem_sbuf+#21
 	LD	DE,#002E
 	CALL	m_chk_alloc
 	JP	C,m_freeall
 
-	LD	B,#01	;installeer 1 labelbuffer
+	LD	B,#01	;install 1 label buffer
 	LD	IY,i_mem_sbuf+#B8
 	CALL	m_chk_alloc
 	JP	C,m_freeall
 
-	CALL	C26B4	;installeer 4 compassblocks
-	JP	C,m_freeall	;***gemakkelijk te maken zoals vorige**
+	CALL	C26B4	;install 4 compass blocks
+	JP	C,m_freeall	;***easy to make like previous**
 
 	LD	HL,i_mem_sbuf
 	LD	DE,mem_tabel
@@ -1224,7 +1224,7 @@ J26C3:	PUSH	IY
 	PUSH	DE
 	LD	A,B
 	OR	A
-	JR	Z,J26E9	;alle segm. op deze entry afgewerkt
+	JR	Z,J26E9	;all segment. finished on this entry
 J26CC:	PUSH	BC
 	LD	B,(IY+#00)
 	INC	IY
@@ -1232,7 +1232,7 @@ J26CC:	PUSH	BC
 	INC	IY
 	CALL	m_src_b_a
 	POP	BC
-	JR	C,J26F3	;segment niet gevonden
+	JR	C,J26F3	;segment not found
 	SET	6,(IX+#00)
 	DJNZ	J26CC
 J26E9:	POP	DE
@@ -1248,7 +1248,7 @@ J26F3:	POP	DE
 	SCF
 	RET
 
-;******************************************einde memroutines
+;******************************************** end of mem routines
 ld_blokb_2c	di
 	ld	a,b
 	OUT	(#FE),A
@@ -1268,7 +1268,7 @@ set_DTA	LD	(curr_DTA),DE
 
 load_data	LD	A,(stat_dos)
 	CP	#02
-	LD	DE,fcb_compass	;load in dos1 klaarzetten
+	LD	DE,fcb_compass	;prepare load in dos1
 	LD	C,#27
 	JR	C,eindload
 	LD	DE,(curr_DTA)	;load in dos2
@@ -1299,7 +1299,7 @@ skipmap1	LD	A,C
 	LDIR
 	RET
 
-;*******************************************************datagebied
+;*********************************************************data area
 compass_ID	db	"COMPASS",0
 txt_inmem	db	"Compass already in memory !",13,10,"$"
 txt_msx1	db	"Minimal MSX 2 required !",13,10,"$"
@@ -1339,17 +1339,17 @@ txt_lderr	db	"Load error !",13,10,10,"$"
 txt_lddone	db	"done",13,10,10,"All engines ready.",13,10,"$"
 txt_launch	db	"Launching Compass...",13,10,"$"
 
-nr_max	dw	14*256	;default: zoek zoveel mogelijk
+nr_max	dw	14*256	;default: search as much as possible
 stat_dos	db	0
 stat_mem	db	0
 primmap_slot	db	0
-work_ROMRAM	ds	#60,0	;hier komt de ROMRAMslottabel, moet 0!
+work_ROMRAM	ds	#60,0	;here comes the ROMRAMslot table, must be 0!
 mem_tabel	ds	#c1,0
 compass_0	dw	0
 compass_1	dw	0
 compass_2	dw	0
 compass_3	dw	0
-tab_TPA	db	3,2,1,0	;default TPAsegments for page 0,1,2 en 3
+tab_TPA	db	3,2,1,0	;default TPAsegments for page 0,1,2 and 3
 decstr	ds	6,0
 env_program	db	"PROGRAM",0
 env_compass	db	"COMPASS",0
@@ -1363,21 +1363,21 @@ m_priortab	db	4,1,1,5,255,1,2,1,6,4,1,1,5,1
 	db	255,1,4,1,8,3,3,1,7,4,4,1,8,4,4,1
 	db	8,3,4,1,8,0
 
-inst	db	0	;0=nog een maagdelijk programma
-	;                        -->dus opstartlogo tonen+src_mem
-	db	0	;sla srcmem niet over
-i_new	equ	inst+#00	;splinternieuwe compass 0=ja
-i_skipsrcmem	equ	inst+#01	;moet de searchmem overgeslagen w?0=nee
+inst	db	0	;0=another virginal program
+	                        ;-->then show boot logo+src_mem
+	db	0	;don't skip srcem
+i_new	equ	inst+#00	;brand new compass 0=yes
+i_skipsrcmem	equ	inst+#01	;should the searchmem be skipped w?0=no
 i_mem_sbuf	equ	inst+#02	;sbuf,datbuf,labelbuf config
-i_cblocks	equ	inst+#c3	;compassblocks
-i_logo	equ	inst+#eb	;logo tonen 1=ja
-i_limit	equ	inst+#11b	;max.aantal te alloceren blokken (5-96)
-	ds	(i_limit)-$,0	;gebied voor allerlei instellingen
-	db	9	;max te installeren blokken in limitmode
+i_cblocks	equ	inst+#c3	;compass blocks
+i_logo	equ	inst+#eb	;show logo 1=yes
+i_limit	equ	inst+#11b	;max.number of blocks to be allocated (5-96)
+	ds	(i_limit)-$,0	;area for all kinds of settings
+	db	9	;max blocks to install in limit mode
 inst_end
 
 tempbuffer	ds	4,0
-buffer	;buffer: overschrijft logoprog
+buffer	;buffer: overwrites logoprog
 
 logoprog	di
 	XOR	A
@@ -1390,7 +1390,7 @@ logoprog	di
 	ld	iy,(#fcc0)
 	call	#001c
 
-	ld	a,(#f3e0)	;beeld uit
+	ld	a,(#f3e0)	;screen off
 	and	#bf
 	out	(#99),a
 	ld	a,128+1
@@ -1441,7 +1441,7 @@ _transend
 	otir
 
 
-	ld	a,(#f3e0)	;beeld aan
+	ld	a,(#f3e0)	;screen on
 	or	#40
 	out	(#99),a
 	ld	a,128+1
@@ -1496,7 +1496,7 @@ WVDP2	NOP
 	ret
 
 vdphmmc	db	10,0,45,0,238,0,101,0
-	db	0,0,#f0	;eerste2pixels nul!!
+	db	0,0,#f0	;first2pixels zero!!
 vdpclean	db	0,0,0,0,0,1,212,0,#00,0,#c0
 
 paletfig

--- a/Compass129Sources/DATfile/ASS129.ASC
+++ b/Compass129Sources/DATfile/ASS129.ASC
@@ -1,20 +1,20 @@
-;Assemblymodule #1.2.09
+;Assembly module #1.2.09
 ;JDS 7/9/1999
 
-;indien de msx vastloopt bij assembleren ligt het aan de ds #7000-$,0
-;op 't einde van de source (de source is dan te groot)
-;ofwel door ds $-free
+;if the msx crashes while assembling it is the ds #7000-$,0
+;at the end of the source (the source is then too big)
+;either by ds $-free
 
-;bevat patch voor de INCLUDE problemen in monitorsegment
+;contains patch for the INCLUDE issues in monitor segment
 patchinclmon	equ	#7ff0
 
 	.label	14
-jon_len_code	equ	127	;vroeger op 64, 127=max ivm (iy+)
-jon_len_rel	equ	127	;vroeger op 64
+jon_len_code	equ	127	;earlier at 64, 127=max due to (iy+)
+jon_len_rel	equ	127	;earlier at 64
 
 bdos:	equ	#f37d
 Doubleadres:	equ	#3f40
-Kbuf:	equ	#f41f	;buffer van 318 bytes
+Kbuf:	equ	#f41f	;318 byte buffer
 
 setvramwrite:	equ	#80
 printtekst	equ	#92
@@ -36,7 +36,7 @@ Cursoronoff:	equ	#fca9
 
 Commline:	equ	12
 
-Tsr_vram:	equ	#2400	;vram-adres TSR-offsets(ook voor public)
+Tsr_vram:	equ	#2400	;vram address TSR offsets (also for public)
 Ext_vram:	equ	#3000
 
 	org	#4000
@@ -50,11 +50,11 @@ Ext_vram:	equ	#3000
 	jp	relocatable	;#4012
 	jp	asstsr	;#4015
 
-Assembledisk:	defb	0	;deze 3 in deze volgorde laten staan
+Assembledisk:	defb	0	;leave these 3 in this order
 Tsr:	defb	0
 Relocatable:	defb	0
 
-;------ TSR assembleren
+;------ Assemble TSR
 asstsr:
 	ld	(Used_fcb),de
 	ld	(Foutadres),iy
@@ -69,7 +69,7 @@ Offsetadres:	defw	0
 Tsrhooks:	defb	0
 Tsrpass:	defb	0
 
-;------ Relocatable assembleren
+;------ Relocatable assembly
 
 relocatable:
 	ld	(Used_fcb),de
@@ -103,7 +103,7 @@ beep:
 	pop	af
 	ret
 
-;------ Assembleren naar disk
+;------ Assemble to disk
 
 assembledisk:
 	ld	(Used_fcb),de
@@ -132,7 +132,7 @@ _relcont:
 	ld	a,(Aantallabelb)
 	ld	b,a
 	ld	ix,Labelbuffers
-	call	GO_wisbuffe1	;wis labelbuffer
+	call	GO_wisbuffe1	;clear label buffer
 
 	ld	hl,8*80+24
 	ld	de,Ass_hok
@@ -195,8 +195,8 @@ Okadres:	defw	0
 _asse1:
 	ld	a,(Assembledisk)
 	or	a
-	jp	nz,patchinclmon	;PATCH naar 7ff0 in monitor
-	;jp      nz,closefile
+	jp	nz,patchinclmon	;PATCH to 7ff0 in monitor
+	;jp nz,closefile
 	ld	hl,Ass_text2
 	call	texttoblok
 	ld	hl,14*80+35
@@ -223,7 +223,7 @@ _labbufvol:
 	ld	a," "
 	jr	z,_errorfoun1
 	ld	a,"s"
-_errorfoun1:	ld	(Error+6),a	;1 error en 0/2 errors  
+_errorfoun1:	ld	(Error+6),a	;1 error and 0/2 errors
 	call	printdecimaa
 	ld	h,#80
 	ld	bc,Error
@@ -236,7 +236,7 @@ _errorfoun1:	ld	(Error+6),a	;1 error en 0/2 errors
 	INC	HL
 	OR	(HL)
 
-	jp	nz,patchinclmon	;PATCH naar 7ff0 in monitor
+	jp	nz,patchinclmon	;PATCH for 7ff0 in monitor
 	;jp      nz,closefile
 
 	call	GOpushanykey	;3F5E
@@ -271,7 +271,7 @@ _ESCtest	IN	A,(#AA)
 	OR	(HL)
 	INC	HL
 	OR	(HL)
-	jp	nz,patchinclmon	;PATCH naar 7ff0 in monitor
+	jp	nz,patchinclmon	;PATCH for 7ff0 in monitor
 	;JP      NZ,closefile
 	JR	_pushkeyback
 
@@ -300,7 +300,7 @@ Ass_text2:
 	defb	"End:",0
 	defw	0
 
-;--------------- Definieer labels en stop in labelbuffer
+;--------------- Define labels and stop in label buffer
 
 labelassembl:
 	ld	hl,Labels1
@@ -318,11 +318,11 @@ labelassembl:
 	ld	(Csegcomm),a
 	ld	(Dsegcomm),a
 	ld	(Phase),a
-	LD	(D5DBD),A	;vermoedelijk, check it**********
+	LD	(D5DBD),A	;presumably, check it**********
 
 	inc	a
 	ld	(Eindlabblok),a
-	ld	(Segment),a	;beginsegment = CSEG
+	ld	(Segment),a	;start segment = CSEG
 	ld	hl,0
 	ld	(Turborcomm),hl
 	ld	(Aantallabels),hl
@@ -333,12 +333,12 @@ labelassembl:
 	ld	(Firstcseg),hl
 	ld	(Firstdseg),hl
 	ld	hl,#0100
-	ld	(Assembladres),hl	;assembleren op #0100
+	ld	(Assembladres),hl	;assemble on #0100
 	call	setif_ini
 	ld	hl,#1910	;***********************************
-	ld	(Erroradres),hl	;doel in vram voor errors  
+	ld	(Erroradres),hl	;target in vram for errors
 	ld	hl,#1c00	;************************************
-	ld	(Macro_opslag),hl	;doel in vram voor macro's  
+	ld	(Macro_opslag),hl	;target in vram for macros
 	ld	a,(Tsr)
 	or	a
 	jr	z,_labelass1
@@ -378,42 +378,42 @@ _nextlabelas:
 	call	geefadrregel
 	jp	c,end_found
 	call	zettextblok
-	call	zinassembl	;haal zin en splits  
-	jp	c,end_found	;einde tekst (na macro)
+	call	zinassembl	;get sentence and split
+	jp	c,end_found	;end of text (after macro)
 
 	ld	hl,Label
 	ld	a,(hl)
 	or	a
 	jr	z,_nolabel
 	cp	"*"
-	jp	z,_ass_error	;"*" van gen80 negeren !
+	jp	z,_ass_error	;ignore "*" from gen80 !
 
 	call	welassembl
-	jr	c,_nolabel	;geen code vanwege if  
+	jr	c,_nolabel	;no code because of if
 	call	putlabel
 	ld	(Labeladres),hl
 	ld	(Labelblok),a
 	ld	(Labeladrdoel),de
 	ld	a,b
 	ld	(Labelblkdoel),a
-	call	c,labelbestond	;label bestond al  
+	call	c,labelbestond	;label already existed
 	ld	a,(Ass_error)
 	or	a
-	jr	nz,_ass_error	;fout bij labels  
+	jr	nz,_ass_error	;error with labels
 	ld	hl,(Aantallabels)
 	inc	hl
 	ld	(Aantallabels),hl
 _nolabel:
 	ld	a,(Macro)
 	push	af
-	call	assemble	;assembleer 1 regel  
+	call	assemble	;assemble 1 line
 	pop	bc
 	ld	a,(Macro)
 	ld	c,a
 	or	b
 	jr	z,_nomacro
 	ld	a,c
-	cp	b	;"MACRO" en "ENDM" niet invullen  
+	cp	b	;Do not enter "MACRO" and "ENDM"
 	call	z,vulmacroin
 	ld	a,(Macro)
 	or	a
@@ -422,13 +422,13 @@ _nolabel:
 _nomacro:
 	ld	a,(Endcode)
 	or	a
-	jp	nz,end_found	;"END" gevonden"
+	jp	nz,end_found	;"END" found"
 	ld	a,(Ass_error)
 	or	a
 	jp	nz,_noequ	;ass_error    ;ERROR !
 
 	call	welassembl
-	jp	c,_ass_error	;geen code vanwege if
+	jp	c,_ass_error	;no code because of if
 	ld	a,(Equ_found)
 	or	a
 	jr	z,_noequ
@@ -445,9 +445,9 @@ _nomacro:
 	and	%11000000
 	cp	%11000000
 	jr	nz,_welequ1
-	ld	a,%01000000	;als beide => CSEG
+	ld	a,%01000000	;if both => CSEG
 _welequ1:
-	call	putlabbuffer	;soort=0 & ABS/CSEG/DSEG
+	call	putlabbuffer	;type=0 & ABS/CSEG/DSEG
 _noequ:
 	ld	a,(Lengtecode)
 	or	a
@@ -459,7 +459,7 @@ _noequ:
 	pop	af
 	cp	#ff
 	ld	bc,(Lengte_defs)
-	jr	z,_noequ1	;defs  
+	jr	z,_noequ1	;defs
 	ld	c,a
 	ld	b,0
 _noequ1:	ld	hl,(Assembladres)
@@ -528,8 +528,8 @@ includeini:
 ;                 or      a
 ;                 jp      nz,bufferinuse
 	ld	(hl),1
-	ld	hl,1	;ZO LATEN    
-	ld	(Assemblregel),hl	;regel 1      
+	ld	hl,1	;LEAVE IT
+	ld	(Assemblregel),hl	;rule 1
 	ret
 
 end_found:
@@ -580,19 +580,19 @@ setif_ini:
 	ret
 
 
-welassembl:	;[C]=niet assembleren  
+welassembl:	;[C]=don't assemble
 	push	hl
 	ld	hl,(If_adres)
 	ld	a,(hl)
 	pop	hl
 	or	a
-	ret	z	;geen if  
+	ret	z	;no if
 	cp	#81
-	ret	z	;wel assembleren  
+	ret	z	;do assemble
 	scf
 	ret
 
-;--------------- Assembleer naar code en stuur naar geheugen
+;--------------- Assemble code and send to memory
 
 codeassemble:
 	call	saveoldsegm
@@ -615,7 +615,7 @@ codeassemble:
 	ld	(Phase),a
 	LD	(D5DBD),A
 	inc	a
-	ld	(Segment),a	;beginsegment = CSEG
+	ld	(Segment),a	;start segment = CSEG
 	ld	hl,0
 	ld	(Turborcomm),hl
 	ld	(Firstorg),hl
@@ -625,7 +625,7 @@ codeassemble:
 	ld	(Aseg),hl
 	ld	hl,#0100
 	ld	(Tijdelasmadr),hl
-	ld	(Assembladres),hl	;assembleren op #0100
+	ld	(Assembladres),hl	;assemble on #0100
 	ld	hl,(Bufferpage0)
 	ld	(Tijdelbuffer),hl
 	ld	de,1024
@@ -633,7 +633,7 @@ codeassemble:
 	ld	(Eindebuffer),hl
 	call	setif_ini
 	ld	hl,#1c00	;********************************
-	ld	(Macro_opslag),hl	;doel in vram voor macro's  
+	ld	(Macro_opslag),hl	;target in vram for macros
 	ld	a,(Tsr)
 	or	a
 	jr	z,_codeass1
@@ -654,7 +654,7 @@ _codeass1:
 	call	speciallink
 	ld	a,%0010
 	ld	b,4
-	call	putbits	;naam file
+	call	putbits	;file name
 	ld	de,(Used_fcb)
 	inc	de
 	ld	b,6
@@ -670,7 +670,7 @@ _vulpublicin:
 	jr	z,_setlength
 	push	bc
 	ld	de,Label
-	ld	b,-1	;B=lengte
+	ld	b,-1	;B=length
 _getpublic:
 	inc	b
 	call	readvram
@@ -684,10 +684,10 @@ _getpublic:
 	call	speciallink
 	ld	a,%0000
 	ld	b,4
-	call	putbits	;naam file
+	call	putbits	;file name
 	pop	bc
 	ld	a,b
-J455D	cp	7	;********************label gebruikt?
+J455D	cp	7	;********************label used?
 	jr	c,_vulpublin1
 	ld	b,6
 _vulpublin1:
@@ -729,21 +729,21 @@ _nextcodeass:
 	call	geefadrregel
 	jp	c,_endcodeass
 	call	zettextblok
-	call	zinassembl	;haal zin en splits  
-	jp	c,_endcodeass	;einde tekst (na macro)
+	call	zinassembl	;get sentence and split
+	jp	c,_endcodeass	;end of text (after macro)
 
 	ld	a,(Label)
 	cp	"*"
-	jp	z,_nocode	;"*" van gen80 negeren !
+	jp	z,_nocode	;ignore "*" from gen80 !
 
-	call	assemble	;assembleer 1 regel  
+	call	assemble	;assemble 1 line
 	ld	a,(Macro)
 	or	a
 	jp	nz,_nocode
 
 	ld	a,(Endcode)
 	or	a
-	jp	nz,_endcodeass	;"END" gevonden
+	jp	nz,_endcodeass	;"END" found
 	ld	a,(Ass_error)
 	or	a
 	jp	nz,_ass_error2	;ERROR !
@@ -757,7 +757,7 @@ _nextcodeass:
 	or	a
 	call	z,set1storg
 	call	welassembl
-	jr	c,_nocode	;niet assembleren vanwege if
+	jr	c,_nocode	;don't assemble because of if
 
 	ld	a,b
 	cp	#ff
@@ -766,7 +766,7 @@ _nextcodeass:
 	ld	a,(Relocatable)
 	or	a
 	push	af
-	call	z,totijdbuffer	;sla in tijdelijke buffer op
+	call	z,totijdbuffer	;save to temporary buffer
 	pop	af
 	call	nz,torelbuffer
 _ass_error1:
@@ -854,7 +854,7 @@ _endcodeass:
 	ld	b,6
 	call	putbits
 	ld	de,0
-	call	putadres	;Einde module: #0000 Abs
+	call	putadres	;End of module: #0000 Abs
 _endcodeass2:
 	ld	a,(Bitinfo)
 	cp	1
@@ -864,13 +864,13 @@ _endcodeass2:
 	jr	_endcodeass2
 _endcodeass3:
 	ld	a,%10011110
-	call	putbyte	;Einde file
+	call	putbyte	;End of file
 	xor	a
 	call	putbit
 	ld	a,1
 	ld	(Assembledisk),a
 _endcodeass1:
-	call	_totijdbuf3	;rest naar ram  
+	call	_totijdbuf3	;remainder to ram
 	ld	a,(Firstcomm)
 	or	a
 	call	z,set1storg
@@ -910,7 +910,7 @@ _publics1:
 	ret	z
 	push	bc
 	ld	de,Label
-	ld	b,-1	;B=lengte 
+	ld	b,-1	;B=length
 _publics2:
 	inc	b
 	call	readvram
@@ -924,14 +924,14 @@ _publics2:
 	call	speciallink
 Publ_ext:	ld	a,%0111
 	ld	b,4
-	call	putbits	;naam file  
+	call	putbits	;file name
 	ld	hl,Label
 	call	labelexist
 	ex	de,hl
 	call	zetlabblok
 	call	getlabbuffer
-	call	getlabbuffer	;+next adres   
-	call	getlabbuffer	;+next blok
+	call	getlabbuffer	;+next address
+	call	getlabbuffer	;+next block
 _publics3:	call	getlabbuffer
 	and	%10000000
 	jr	z,_publics3
@@ -959,8 +959,8 @@ _publics4:
 	pop	bc
 	jr	_publics1
 
-;----- Stuur naamveld
-;----- IN: DE=adres naam, B=aantal tekens (max. 6)
+;----- Send name field
+;----- IN: DE=address name, B=number of characters (max. 6)
 putname:
 	push	bc
 	ld	a,b
@@ -980,21 +980,21 @@ _putname2:
 	djnz	_putname1
 	ret
 
-;----- Special-link-item id sturen
+;----- Send special link item id
 speciallink:
 	ld	a,%100
 	ld	b,3
 	jr	putbits
 
-;----- Stuur adres naar buffer
-;----- IN: DE=adres
+;----- Send address to buffer
+;----- IN: DE=address
 putadres:
 	ld	a,e
 	call	putbyte
 	ld	a,d
 	jr	putbyte
 
-;----- Stuur 1 byte naar buffer
+;----- Send 1 byte to buffer
 ;----- IN: A=byte
 putbyte:
 	ld	b,8
@@ -1006,7 +1006,7 @@ _putbyte1:
 	djnz	_putbyte1
 	ret
 
-;----- Stuur B bits uit A naar buffer (Bits in A rechts !)
+;----- Send B bits from A to buffer (Bits in A right!)
 
 putbits:
 	push	bc
@@ -1020,7 +1020,7 @@ _putbits2:
 	djnz	_putbits2
 	ret
 
-;----- Stuur 1 bit naar buffer
+;----- Send 1 bit to buffer
 
 putbit:
 	push	af
@@ -1055,7 +1055,7 @@ Bitinfo:	defb	9
 Huidigbyte:	defb	0
 
 
-;----- voer DEFS uit
+;----- run DEFS
 
 _do_defs:
 	ld	hl,(Lengte_defs)
@@ -1106,7 +1106,7 @@ _defs_rel1:	ld	a,h
 vultijdbuffe:
 	ld	hl,(Tijdelbuffer)
 	ld	a,(Eindebuffer)
-	ld	c,a	;highbyte einde  
+	ld	c,a	;high byte end
 _vultijdbuf1:
 	ld	a,(Vul_defs)
 	ld	(hl),a
@@ -1128,7 +1128,7 @@ vultijdrel:
 	djnz	vultijdrel
 	ret
 
-;----- IN: B=lengte
+;----- IN: B=length
 
 torelbuffer:
 	ld	iy,Code
@@ -1136,7 +1136,7 @@ _torelbuff1:
 	push	bc
 	ld	a,(iy+jon_len_code)
 	or	a
-	jr	z,_torelbuff2	;gewone code
+	jr	z,_torelbuff2	;regular code
 	ld	(iy+jon_len_code),0
 	scf
 	call	putbit
@@ -1148,8 +1148,8 @@ _torelbuff1:
 	inc	iy
 	call	putadres
 	pop	bc
-	dec	b	;1 extra byte gebruikt
-	ret	z	;kan niet, maar voor de zekerheid
+	dec	b	;1 extra byte used
+	ret	z	;not possible, but just to be sure
 	jr	_torelbuff3
 _torelbuff2:
 	xor	a
@@ -1162,7 +1162,7 @@ _torelbuff3:
 	djnz	_torelbuff1
 	ret
 
-;----- IN: B=lengte
+;----- IN: B=length
 
 totijdbuffer:
 	ld	a,(Tsr)
@@ -1176,7 +1176,7 @@ _totijdbuf4:
 _bytenaarbuf:
 	ld	hl,(Tijdelbuffer)
 	ld	a,(Eindebuffer)
-	ld	c,a	;lowbyte einde
+	ld	c,a	;low byte end
 _totijdbuf1:
 	ld	a,(de)
 	inc	de
@@ -1189,10 +1189,10 @@ _totijdbuf1:
 	ld	(Tijdelbuffer),hl
 	ret
 
-_totijdbuf2:	;naar ram/disk sturen  
+_totijdbuf2:	;send to ram/disk
 	ld	a,(Eindebuffer+1)
 	cp	h
-	ret	nz	;nog niet einde
+	ret	nz	;not end yet
 	push	bc
 	push	de
 	ld	a,(Assembledisk)
@@ -1215,7 +1215,7 @@ _codetodisk:
 	call	savedisk
 	jr	codediskcont
 
-_totijdbuf3:	;tussentijds naar ram sturen
+_totijdbuf3:	;send to ram in the meantime
 	ld	hl,(Tijdelbuffer)
 	ld	de,(Bufferpage0)
 	ld	(Tijdelbuffer),de
@@ -1223,7 +1223,7 @@ _totijdbuf3:	;tussentijds naar ram sturen
 	sbc	hl,de
 	ld	a,h
 	or	l
-	jr	z,_totijdb3_1	;niets te sturen
+	jr	z,_totijdb3_1	;nothing to send
 	ld	a,(Assembledisk)
 	or	a
 	jr	nz,codetodis1
@@ -1238,11 +1238,11 @@ codetodis1:
 	call	savedisk
 	jr	_totijdb3_1
 
-Tijdelbuffer:	defw	0	;huidige adres tijdelijke buffer
-Tijdelasmadr:	defw	0	;assembleeradres begin buffer  
-Eindebuffer:	defw	0	;einde tijdelijke buffer  
+Tijdelbuffer:	defw	0	;current address temporary buffer
+Tijdelasmadr:	defw	0	;assemble address start buffer
+Eindebuffer:	defw	0	;end of temporary buffer
 
-;----- haal zin om te assembleren en splits    UIT: [C]=einde tekst (na macro) 
+;----- get sentence to assemble and split      OUT: [C]=end text (after macro)
 
 zinassembl:
 	ld	hl,Zin
@@ -1256,13 +1256,13 @@ _zinassembl1:	call	gettxtbuffer
 	jr	z,_zinassembl1
 	ld	(hl),0
 	dec	hl
-	res	7,(hl)	;ZIN is regel met tabs, 0=einde
+	res	7,(hl)	;SENTENCE is line with tabs, 0=end
 	call	splitline
 	xor	a
-	ld	(hl),a	;laatste afsluiten
+	ld	(hl),a	;last exit
 	ret
 
-;---------- Vul labels bij macro-text in
+;---------- Enter labels for macro text
 
 textmacro:
 	ld	a,(Macrotxtblk)
@@ -1291,10 +1291,10 @@ _textmacrend:
 	ld	a,(Labbloknr)
 	ld	(Macrotxtblk),a
 	call	splitline
-	ld	(hl),0	;laatste afsluiten  
+	ld	(hl),0	;last exit
 	xor	a
 	ret
-_textmacrstp:	;einde macro bereikt  
+_textmacrstp:	;end of macro reached
 	ld	hl,Huidigmacro
 	dec	(hl)
 	jr	z,_lastmacro
@@ -1308,14 +1308,14 @@ _lastmacro:
 	inc	de
 	ld	(Assemblregel),de
 	call	geefadrregel
-	ret	c	;einde tekst (na macro)  
+	ret	c	;end of text (after macro)
 	call	zettextblok
-	jp	zinassembl	;verder met gewoon assembleren  
+	jp	zinassembl	;continue with just assembling
 
 
-;----- vervangt macro-label door meegegeven tekst
+;----- replace macro label with given text
 
-vulmacrlabin:	;vul macro-label in
+vulmacrlabin:	;fill in macro label
 	push	hl
 	ld	hl,Kbuf+200
 _textmacro2:
@@ -1326,7 +1326,7 @@ _textmacro2:
 	ld	(Macrocntblk),a
 	call	getlabbuffer
 	call	tekenlabelok
-	jr	nc,_textmacro2	;haal label met @ op  
+	jr	nc,_textmacro2	;fetch label with @
 	ld	(hl),0
 
 	call	macrolabadrs
@@ -1344,10 +1344,10 @@ _vultxtin3:
 Macrocntadr:	defw	0
 Macrocntblk:	defb	0
 
-Turborcomm:	defw	0	;aantal turbo-r commando's  
+Turborcomm:	defw	0	;number of turbo-r commands
 
 
-;----- tekst naar macro
+;----- text to macro
 
 vulmacroin:
 	ld	a,(Macrobufblk)
@@ -1365,13 +1365,13 @@ _vulmacroin1:
 	ld	(Macrobufblk),a
 	ret
 
-;----- Haalt adres inhoud van macro-label op
-;----- UIT: DE=adres, [C]=label not defined
+;----- Retrieves address contents of macro label
+;----- OUT: DE=address, [C]=label not defined
 
 macrolabadrs:
 	ld	de,Kbuf
 	ld	b,0
-_textmacro4:	;controleer welk label  
+_textmacro4:	;check which label
 	ld	hl,Kbuf+200
 	inc	b
 _textmacro3:
@@ -1393,7 +1393,7 @@ _textmacro5:
 	inc	de
 	jr	_textmacro5
 _vultxtin:
-	ld	de,Kbuf+100	;lang genoeg?***********************
+	ld	de,Kbuf+100	;long enough?***********************
 	dec	b
 	ret	z
 _vultxtin1:
@@ -1404,7 +1404,7 @@ _vultxtin1:
 	djnz	_vultxtin1
 	ret
 
-;----- geef label-data adres door aan editor
+;----- pass label data address to editor
 
 geeflabdata:
 	ld	hl,Labels1
@@ -1415,14 +1415,14 @@ geeflabdata:
 	ret
 
 
-;----- label naar labelbuffer   IN: HL=adres
-;---------- UIT: [C]=bestond al, HL=adres, A=bloknr (1-..)
-;             als [NC]: DE=doeladres adres/blok, B=doelbloknr 
-;*** Label: adres+blok volgende, label (einde=bit7), adres, blok, soort
-;    soort: 0=normaal, <>0=macro
+;----- label to label buffer   IN: HL=address
+;---------- OUT: [C]=already existed, HL=address, A=block number (1-..)
+;            if [NC]: DE=target address address/block, B=target block num
+;*** Label: address+block next, label (end=bit7), address, block, type
+;    kind: 0=normal, <>0=macro
 
 Aantallabels:	defw	0
-Labels1:	defs	3*26+3*1	;26+1 keer adres,blok  
+Labels1:	defs	3*26+3*1	;26+1 times address, block
 
 putlabel:
 	ld	a,(Labelpublic)
@@ -1439,40 +1439,40 @@ putlabel2:
 	call	savepublic1
 	pop	hl
 putlabel1:
-	call	labelcorrect	;test of goed label  
+	call	labelcorrect	;test for good label
 	jr	nc,_putlab1
 	ld	a,b
 	or	a
-	jp	z,badlabel	;fout
+	jp	z,badlabel	;wrong
 	jp	labeltoolong
 _putlab1:
 	ld	a,(Macro)
 	or	a
-	ret	nz	;Labels in macro zelf niet invullen  
+	ret	nz	;Do not fill in labels in macro itself
 	ld	a,1
-	call	labelexist	;met invullen  
+	call	labelexist	;with fill in
 	ccf
-	ret	c	;bestond al
+	ret	c	;already existed
 
 	push	af
 	push	hl
-	ex	de,hl	;de=doel  
+	ex	de,hl	;de=target
 	call	zetlabblok
 	xor	a
 	call	putlabbuffer
 	xor	a
 	call	putlabbuffer
 	xor	a
-	call	putlabbuffer	;adres+blok volgende = 0,0,0
-	ld	hl,Label	;hl=bron  
-	ld	c,3+1	;3 tekens (adres/blok next)  
+	call	putlabbuffer	;address+block next = 0,0,0
+	ld	hl,Label	;hl=source
+	ld	c,3+1	;3 characters (address/block next)
 
 _putnext:
 	ld	a,(Upperonoff)
 	or	a
 	ld	a,(hl)
 	inc	hl
-	jr	z,_putnext1	;niet upper
+	jr	z,_putnext1	;not upper
 	cp	"a"
 	jr	c,_putnext1
 	cp	"z"+1
@@ -1488,7 +1488,7 @@ _putnext1:	ld	b,a
 	jr	_putnext
 _end_put:
 	or	%10000000
-	call	putlabbuffer	;laaste letter => bit 7 hoog
+	call	putlabbuffer	;last letter => bit 7 high
 	ld	a,(Labbloknr)
 	push	af
 	push	de	;*************** 7-3-95
@@ -1496,7 +1496,7 @@ _end_put:
 	ld	a,l
 	call	putlabbuffer
 	ld	a,h
-	call	putlabbuffer	;soort niet ingevuld (was al 0)
+	call	putlabbuffer	;type not filled in (was already 0)
 	ld	a,(Relocatable)
 	ld	b,a
 	ld	a,(Tsr)
@@ -1505,13 +1505,13 @@ _end_put:
 	ld	a,(Segment)	;0=ABS, 1=CSEG, 2=DSEG
 	rrca
 	rrca
-	call	putlabbuffer	;Soort = %??000000
+	call	putlabbuffer	;Type = %??000000
 _end_put2:
 	ld	b,0
 	ld	hl,(Eindlabadres)
 	add	hl,bc
 ;              push    hl                  ******************* 7-3-95
-	ld	c,2+1	;+adres+soort  
+	ld	c,2+1	;+address+type
 	add	hl,bc
 	bit	6,h
 	jr	z,_end_put1
@@ -1522,19 +1522,19 @@ _end_put2:
 	ex	de,hl
 _end_put1:
 	ld	(Eindlabadres),hl
-	pop	de	;de=doeladres adres+soort
-	pop	bc	;b=doelblok   " " " " " "  
-	pop	hl	;beginadres label
-	pop	af	;beginblok label  
+	pop	de	;de=target address address+type
+	pop	bc	;b=target block    " " " " " "
+	pop	hl	;starting address label
+	pop	af	;starting block label
 	or	a
 	ret
 Eindlabadres:	defw	0
 Eindlabblok:	defb	0
 
 
-;---------- Bestaat label al ?
-;----- IN: HL=adres label, A: 0=alleen zoeken, 1=ook adres invullen
-;----- UIT: [C]=nee, HL=adres (als [C]=>doel label), A=bloknr, DE=einde label
+;---------- Does label already exist?
+;----- IN: HL=address label, A: 0=search only, 1=also fill in address
+;----- OUT: [C]=no, HL=address (if [C]=>target tag), A=block num, DE=end tag
 
 labelexist:
 	ld	(Alleenzoek),a
@@ -1542,11 +1542,11 @@ labelexist:
 	ld	a,(hl)
 	ld	hl,Labels1+26*3
 	cp	"A"
-	jr	c,_labexist1	;speciaal  
+	jr	c,_labexist1	;special
 	cp	"Z"+1
 	jr	c,_labexist2	;letter
 	cp	"a"
-	jr	c,_labexist1	;speciaal  
+	jr	c,_labexist1	;special
 
 _labexist2:	and	%11011111
 	sub	"A"
@@ -1564,7 +1564,7 @@ _labexist1:
 	inc	hl
 	ld	a,d
 	or	e
-	jp	z,_labexist3	;eerste met deze letter  
+	jp	z,_labexist3	;first with this letter
 	ld	(Nextadres),de
 	ld	a,(hl)
 	ld	(Nextblok),a
@@ -1591,7 +1591,7 @@ _nextexist:
 	ld	(Laatste),a
 _nietlaatste:	call	getlabbuffer
 	ld	(Nextadres),hl
-	ld	(Nextblok),a	;voor volgende keer
+	ld	(Nextblok),a	;for next time
 
 	ld	hl,(Adreslabel)
 _nextcompare:
@@ -1602,7 +1602,7 @@ _nextcompare:
 	ld	a,(Upperonoff)
 	or	a
 	ld	a,(hl)
-	jr	z,_nextcompar1	;geen upper
+	jr	z,_nextcompar1	;no upper
 	cp	"a"
 	jr	c,_nextcompar1
 	cp	"z"+1
@@ -1619,7 +1619,7 @@ _maybe:
 	ld	a,(Upperonoff)
 	or	a
 	ld	a,(hl)
-	jr	z,_maybe1	;geen upper
+	jr	z,_maybe1	;no upper
 	cp	"a"
 	jr	c,_maybe1
 	cp	"z"+1
@@ -1631,7 +1631,7 @@ _maybe1:
 	inc	hl
 	ld	a,(hl)
 	call	tekenlabelok
-	jr	nc,_nextexist	;niet einde  
+	jr	nc,_nextexist	;not end
 _labelfound:
 	ex	de,hl
 	ld	hl,(Testadres)
@@ -1644,13 +1644,13 @@ Testadres:	defw	0
 Nextblok:	defb	0
 Nextadres:	defw	0
 Adreslabel:	defw	0
-Laatste:	defb	0	;1=laatste test (next adress=0)  
-Alleenzoek:	defb	0	;0=alleen zoeken, 1=ook adres invullen  
+Laatste:	defb	0	;1=last test (next address=0)
+Alleenzoek:	defb	0	;0=search only, 1=also fill in address
 
 _labnotfound:
 	ld	a,(Alleenzoek)
 	or	a
-	jr	z,_labnotfoun1	;alleen zoeken  
+	jr	z,_labnotfoun1	;only search
 	ld	a,(Testblok)
 	call	zetlabblok
 	ld	de,(Testadres)
@@ -1667,10 +1667,10 @@ _labnotfoun1:
 	scf
 	ret
 
-_labexist3:	;1e van deze letter/teken  
+_labexist3:	;1st of this letter/character
 	ld	a,(Alleenzoek)
 	or	a
-	jr	z,_labnotfoun1	;alleen zoeken  
+	jr	z,_labnotfoun1	;only search
 
 	ld	a,(Eindlabblok)
 	ld	(hl),a
@@ -1684,8 +1684,8 @@ _labexist3:	;1e van deze letter/teken
 	ret
 
 
-;----- Test of label correct is    IN: HL=beginadres   UIT: [C]=niet correct
-;----- UIT: B=0 => bad label, B=1 => label too long
+;----- Test if label is correct    IN: HL=start address    OUT: [C]=incorrect
+;----- OUT: B=0 => bad label, B=1 => label too long
 
 labelcorrect:
 	ld	b,0
@@ -1743,7 +1743,7 @@ _bin_na1:
 	ld	a,(hl)
 	or	a
 	scf
-	jr	z,_not_ok	;leeg
+	jr	z,_not_ok	;empty
 	ld	a,(Labellengte)
 	inc	a
 	ld	b,a
@@ -1765,7 +1765,7 @@ _not_ok:
 	ld	b,0
 	ret
 
-;---------- Test tekens die achter label kunnen komen  [C]=niet gevonden
+;---------- Test characters that can come after label  [C]=not found
 
 testfound1:
 	ld	b,15
@@ -1780,7 +1780,7 @@ _testfound2:	ld	a,(de)
 Testfound:	defb	0,34," ,^*/+-()=<>@"
 
 
-;----- mag teken in label voorkomen ?  UIT: [C]=nee 
+;----- may character appear in label ?  OUT: [C]=no
 tekenlabelok:
 	ex	af,af'
 	ld	a,(Macro)
@@ -1788,7 +1788,7 @@ tekenlabelok:
 	jr	z,_tekenlabok1
 	ex	af,af'
 	cp	"@"
-	ret	z	;@ mag bij macro ook
+	ret	z	;@ is also allowed with macro
 	ex	af,af'
 _tekenlabok1:
 	ex	af,af'
@@ -1819,19 +1819,19 @@ _tekenlabok1:
 	ccf
 	ret
 
-;----- splits zin in label, commando, register 1 en register 2
+;----- split sentence into label, command, register 1 and register 2
 
-Labelpublic:	defb	0	;1=label:: , dus public
+Labelpublic:	defb	0	;1=label:: , so public
 
 splitline:
 	xor	a
 	ld	(Label),a
 	ld	(Commando),a
 	ld	(Labelpublic),a
-	LD	HL,reg_kweenie	;=Zin-5  ************************
-	LD	(reg1_pointer),HL	;=Zin-4
-	LD	(reg2_pointer),HL	;=Zin-2
-	ld	de,Zin	;label  
+	LD	HL,reg_kweenie	;= Sentence-5  ************************
+	LD	(reg1_pointer),HL	;=Sentence-4
+	LD	(reg2_pointer),HL	;=Sentence-2
+	ld	de,Zin	;label
 	ld	hl,Label
 _splitlabel1:	ld	a,(de)
 	inc	de
@@ -1863,7 +1863,7 @@ _splitcomm1:	ld	a,(de)
 	cp	" "
 	jr	z,_splitcomm1
 	dec	de
-	ld	hl,Commando	;commando  
+	ld	hl,Commando	;command
 _splitcomma1:	ld	a,(de)
 	inc	de
 	or	a
@@ -1917,7 +1917,7 @@ _splitreg1_2:	ld	(hl),a
 	jr	_splitreg1_1
 noreg2	ld	(hl),0
 	inc	hl
-	ld	(reg2_pointer),hl	;nodig voor IF ar1>arg2
+	ld	(reg2_pointer),hl	;needed for IF ar1>arg2
 	ret
 _splitregis2:
 	xor	a
@@ -1926,9 +1926,9 @@ _splitregis2:
 _splitreg2_3:	ld	a,(de)
 	inc	de
 	cp	9
-	jr	z,_splitreg2_3	;alle tabs wegwerken  
+	jr	z,_splitreg2_3	;get rid of all tabs
 	cp	" "
-	jr	z,_splitreg2_3	;alle spaties wegwerken
+	jr	z,_splitreg2_3	;remove all spaces
 	dec	de
 	INC	HL
 	LD	(reg2_pointer),HL
@@ -1958,7 +1958,7 @@ _weltab:
 	jr	nz,_nottab1
 	ld	a,(ix+2)
 	cp	"'"
-	jr	z,_endreg2	;einde na af'
+	jr	z,_endreg2	;end after af'
 _nottab1:	ld	a,b
 _nottab:
 	cp	34	;"  
@@ -1979,10 +1979,10 @@ _splitreg2_2:	ld	(hl),a
 _endreg2:	ld	de,(reg2_pointer)	;*****************************
 	ld	a,(de)
 	or	a
-	ret	nz	;na "," wel 2e register  
+	ret	nz	;after "," or 2nd register
 	inc	a
 	LD	DE,(reg1_pointer)	;*******************************
-	ld	(de),a	;verniel register 1
+	ld	(de),a	;destroy register 1
 	ret
 
 _split_aanha:
@@ -2004,7 +2004,7 @@ _split_aanh1:
 
 Splitaanhali:	defb	0
 
-;----- Vertaal 1 regel naar code
+;----- Translate 1 line to code
 
 assemble:
 	xor	a
@@ -2013,11 +2013,11 @@ assemble:
 	ld	(Endcode),a
 
 	ld	hl,(Assembladres)
-	ld	(Assembladre1),hl	;kopie voor defb en defw  
+	ld	(Assembladre1),hl	;copy for defb and defw
 	ld	a,(Commando)
 	or	a
-	ret	z	;geen commando
-	ld	(Sp_assemble),sp	;voor errors  
+	ret	z	;no command
+	ld	(Sp_assemble),sp	;for errors
 
 	call	testcommando
 	jr	c,_testmacro
@@ -2029,25 +2029,25 @@ _testmacro:
 	or	a
 	ret	nz
 	call	welassembl
-	ret	c	;niet assembleren vanwege if  
+	ret	c	;don't assemble because of if
 	ld	hl,Commando
 	xor	a
 	call	labelexist
-	jp	c,badcommand	;ook geen macro  
+	jp	c,badcommand	;no macro either
 	call	zetlabblok
 	ex	de,hl
 	call	getlabbuffer
 	call	getlabbuffer
-	call	getlabbuffer	;adres+blok volgend
+	call	getlabbuffer	;address+block next
 _testmacro1:
 	call	getlabbuffer
 	and	%10000000
-	jr	z,_testmacro1	;naam  
+	jr	z,_testmacro1	;name
 	call	getlabbuffer
 	call	getlabbuffer
 	call	getlabbuffer
 	and	1
-	jp	z,badcommand	;label is geen macro  
+	jp	z,badcommand	;label is not a macro
 
 	push	de
 	ld	hl,Huidigmacro
@@ -2057,7 +2057,7 @@ _testmacro1:
 	call	nz,savemacro
 	ld	hl,Sym
 	ld	de,Kbuf
-	ld	bc,10	;@SYM en @sym  
+	ld	bc,10	;@SYM and @sym
 	ldir
 	ex	de,hl
 	pop	de
@@ -2066,7 +2066,7 @@ _testmacro3:
 	ld	(hl),a
 	inc	hl
 	inc	a
-	jr	nz,_testmacro3	;macro-labels naar Kbuf  
+	jr	nz,_testmacro3	;macro labels to Kbuf
 	ld	a,(Labbloknr)
 	ld	(Macrotxtblk),a
 	ld	(Macrotxtadr),de
@@ -2098,13 +2098,13 @@ _testmacrend:
 fillwith0:
 	ld	(hl),0
 	inc	hl
-	djnz	fillwith0	;rest met 0 vullen
+	djnz	fillwith0	;fill remainder with 0
 	ld	a,1
 	ld	(Domacro),a
 	ret
 
-Domacro:	defb	0	;macro tussenvoegen ? 0=nee, 1=ja  
-Macrotxtblk:	defb	0	;blok+adres macro-text  
+Domacro:	defb	0	;insert macro ? 0=no, 1=yes
+Macrotxtblk:	defb	0	;block+address macro-text
 Macrotxtadr:	defw	0
 
 vulsymin:
@@ -2129,15 +2129,15 @@ Sym:	defb	"@SYM",0,"@sym",0
 Sym_waarde:	defw	0
 
 
-;----- maak lijst van macrolabels met waarden in geheugen
+;----- list macro labels with values ​​in memory
 
 macrolist:
 	ld	a,(ix)
 	or	a
 	scf
-	ret	z	;einde  
+	ret	z	;end
 	xor	a
-	ld	(Macroaanhal),a	;aanhalingstekens uit  
+	ld	(Macroaanhal),a	;quotes off
 _macrolist1:
 	ld	a,(ix)
 	inc	ix
@@ -2182,10 +2182,10 @@ _macroaanh1:
 	ld	a,b
 	ld	(Macroaanhal),a
 _macroaanh2:
-	ld	a,b	;ZO LATEN !
+	ld	a,b	;LEAVE IT !
 	jr	_macrolist3
 
-;----- Save/laad macro naar/uit vram
+;----- Save/load macro to/from vram
 
 savemacro:
 	ld	hl,(Macro_opslag)
@@ -2212,7 +2212,7 @@ _savemacro4:
 	djnz	_savemacro4
 	pop	de
 	call	_savemacro2
-	ld	(Macro_opslag),hl	;adres voor volgende macro  
+	ld	(Macro_opslag),hl	;address for next macro
 	ret
 _savemacro1:
 	out	(#98),a
@@ -2271,20 +2271,20 @@ Macro_opslag:	defw	0
 Huidigmacro:	defb	0
 
 
-;----- Test of commando bestaat    UIT: [C]=nee, HL=startadres
-;----- lengte en 1e code ingevuld
-testcommando	ld	a,(Commando)	;normaalgezien <128
-	add	a,a	;maal twee
+;----- Test if command exists       OUT: [C]=no, HL=start address
+;----- length and 1st code entered
+testcommando	ld	a,(Commando)	;normally <128
+	add	a,a	;times two
 	ld	l,a
 	ld	h,tabcom/256
 	ld	a,(hl)
 	inc	hl
 	ld	h,(hl)
 	ld	l,a
-	ld	a,(hl)	;getaantal met deze beginletter
+	ld	a,(hl)	;getnumber with this initial letter
 	or	a
 	scf
-	ret	z	;geen commando's met deze letter
+	ret	z	;no commands with this letter
 	inc	hl
 	ld	b,0
 zoekcommand	ex	af,af'
@@ -2321,16 +2321,16 @@ comfound	ld	a,(hl)
 
 
 Assembladres:	defw	0
-Assembladre1:	defw	0	;kopie voor defb en defw
+Assembladre1:	defw	0	;copy for defb and defw
 Assemblregel:	defw	0
-Lengtecode:	defb	0	;#ff=defs  
+Lengtecode:	defb	0	;#ff=defs
 Code:	defs	jon_len_code,0
-Relcode:	defs	jon_len_rel,0	;bij elke byte: 0=abs, 1=cseg, 2=dseg
+Relcode:	defs	jon_len_rel,0	;at each byte: 0=abs, 1=cseg, 2=dseg
 Lengte_defs:	defw	0
 Vul_defs:	defb	0
-Endcode:	defb	0	;0=niet einde, 1=wel einde code  
-Equ_adres:	defw	0	;adres bij equ  
-Equ_found:	defb	0	;0=niet gevonden, 1=wel
+Endcode:	defb	0	;0=not end, 1=end code
+Equ_adres:	defw	0	;address at equ
+Equ_found:	defb	0	;0=not found, 1=yes
 Pass:	defb	0
 
 
@@ -2395,7 +2395,7 @@ _add_ix_iy1:	push	af
 	jp	c,badmnemonic
 	cp	b
 	ld	(iy+1),#29
-	ret	z	;IX,IX en IY,IY
+	ret	z	;IX,IX and IY,IY
 	inc	iy
 	cp	10
 	jr	z,_add_cont
@@ -2458,7 +2458,7 @@ _bit_ix_iy1:	ld	a,(iy+1)
 	jp	nz,badmnemonic
 	ret
 
-bit_ix2:	ld	(iy),#dd	;(ix) en (iy)
+bit_ix2:	ld	(iy),#dd	;(ix) and (iy)
 	jr	_bit_ix_iy2
 bit_iy2:	ld	(iy),#fd
 _bit_ix_iy2:	ld	a,(iy+1)
@@ -2517,13 +2517,13 @@ _dec:
 _dec_cont:
 	cp	8
 	jr	nc,_dec_ix
-	add	a,a	;dec standaard
+	add	a,a	;dec standard
 	add	a,a
 	add	a,a
 	or	(iy)
 	ld	(iy),a
 	ret
-_dec_ix:	cp	10	;dec (ix+ (iy+  
+_dec_ix:	cp	10	;dec (ix+ (iy+
 	jr	nc,_dec_ix1
 	ld	b,a
 	ld	a,(iy)
@@ -2538,8 +2538,8 @@ _dec_ix1:	cp	24	;dec (ix) (iy)
 	ld	b,a
 	ld	a,(iy)
 	add	a,#30
-	jp	test_standa4	;verder bij standaard  
-_dec_bc_de:	cp	14	;dec bc de hl sp  
+	jp	test_standa4	;continue with standard
+_dec_bc_de:	cp	14	;dec bc de hl sp
 	jr	nc,_dec_ix_iy
 	sub	10
 	add	a,a
@@ -2585,16 +2585,16 @@ _djnz_cont:	call	getal16bit
 	ex	af,af'
 	ld	a,(Pass)
 	dec	a
-	ret	z	;Bij pass1 => terug
+	ret	z	;At pass1 => back
 	ex	af,af'
 	jp	c,badmnemonic
-	ex	de,hl	;hl=getal  
+	ex	de,hl	;hl=number
 	ld	de,(Assembladres)
-J565D	inc	de	;******************gebruikt?
+J565D	inc	de	;******************used?
 	inc	de
 	xor	a
 	sbc	hl,de
-	ex	de,hl	;de=adres  
+	ex	de,hl	;de=address
 	ld	a,d
 	dec	a
 	cp	#fe
@@ -2614,7 +2614,7 @@ _ex:
 	jp	c,badmnemonic
 	ld	(iy),#e3
 	cp	12
-	ret	z	;(sp),hl  
+	ret	z	;(sp),hl
 	ld	(iy+1),#e3
 	ld	(iy),#dd
 	inc	(iy-1)
@@ -2728,7 +2728,7 @@ _jp:
 	call	test2ndregis
 	jr	nc,_jp2
 	call	voorwaarde
-	jp	nc,_call_cont1	;jp voorwaarde  
+	jp	nc,_call_cont1	;jp condition
 	ld	(iy),#c3
 	LD	HL,(reg1_pointer)
 	jp	_call_cont
@@ -2745,11 +2745,11 @@ _jp2:	ld	b,a
 	ret	z	;(ix)
 	set	5,(iy)
 	cp	25
-	ret	z	;(iy)  
+	ret	z	;(iy)
 	ld	(iy),#e9
 	dec	(iy-1)
 	cp	6
-	ret	z	;(hl)  
+	ret	z	;(hl)
 	jp	badmnemonic
 
 ;$$$$$ jr
@@ -2810,7 +2810,7 @@ _ld:
 	cp	21+1
 	jp	nc,badmnemonic
 
-_ld_ixh_ixl:	;ld ixh/ixl/iyh/iyl,r1/getal
+_ld_ixh_ixl:	;ld ixh/ixl/iyh/iyl,r1/number
 	ld	hl,(Turborcomm)
 	inc	hl
 	ld	(Turborcomm),hl
@@ -2838,7 +2838,7 @@ _ld_ixh_ixl2:	push	af
 	jr	c,_ld_ixh_1
 	cp	21+1
 	jp	nc,badmnemonic
-_ld_iyh_1:	bit	1,b	;,iyh/iyl  
+_ld_iyh_1:	bit	1,b	;,iyh/iyl
 	jp	z,badmnemonic
 	add	a,#64-20
 	jr	_ld_ixh_3
@@ -2850,7 +2850,7 @@ _ld_ixh_3:	ld	(iy+1),a
 	ret	z
 	set	3,(iy+1)
 	ret
-_ld_ixh_ok:	add	a,(iy+1)	;,b/c/d/e/a  
+_ld_ixh_ok:	add	a,(iy+1)	;,b/c/d/e/a
 	ld	(iy+1),a
 	ret
 _ld_ixh_geta:	bit	0,b
@@ -2871,7 +2871,7 @@ _ld_i_r:
 	cp	7
 	jp	nz,badmnemonic
 	ret
-_ld1_ix_iy:	;ld ix/iy,  
+_ld1_ix_iy:	;ld ix/iy,
 	ld	(iy-1),4
 	LD	HL,(reg2_pointer)
 	call	getalhaakjes
@@ -2961,7 +2961,7 @@ _ld_ix_iy_co:	jp	c,badmnemonic
 	add	a,#70
 	ld	(iy+1),a
 	ret
-_ld_ix_getal:	;(ix/(iy ,getal  
+_ld_ix_getal:	;(ix/(iy ,number
 	ld	(iy+1),#36
 	LD	HL,(reg2_pointer)
 	inc	(iy-1)
@@ -2969,7 +2969,7 @@ _ld_ix_getal:	;(ix/(iy ,getal
 	jp	c,badmnemonic
 	ld	(iy+3),a
 	ret
-_ld_b_c:	;ld r1,r1   (< (HL))  
+_ld_b_c:	;ld r1,r1   (< (HL))
 	ld	(Ld_b_ixh),a
 	add	a,a
 	add	a,a
@@ -2983,21 +2983,21 @@ _ld_b_c:	;ld r1,r1   (< (HL))
 	ret	nz
 	ld	a,(iy)
 	cp	#dd
-	jr	z,_ld_b_ixh	;ixh/ixl  
+	jr	z,_ld_b_ixh	;ixh/ixl
 	cp	#fd
-	jr	z,_ld_b_ixh	;iyh/iyl  
+	jr	z,_ld_b_ixh	;iyh/iyl
 	ld	a,(iy)
 	sub	#46+#3a
-	ld	(iy),a	;herstel fout bij ld r1,getal  
+	ld	(iy),a	;fix error at ld r1,number
 	ret
 _ld_b_ixh:	ld	a,(Ld_b_ixh)
 	cp	4
 	ret	c
 	cp	7
 	ret	z
-	jp	badmnemonic	;niet h/l,ixh enz.
+	jp	badmnemonic	;not h/l,ixh etc.
 Ld_b_ixh:	defb	0
-_ld_a:	;ld a,r1/getal
+_ld_a:	;ld a,r1/number
 	call	test2ndregis
 	jr	c,_ld_a_getal
 	cp	28
@@ -3005,21 +3005,21 @@ _ld_a:	;ld a,r1/getal
 	ret	z	;a,(bc)  
 	cp	29
 	ld	(iy),#1a
-	ret	z	;a,(de)  
+	ret	z	;a,(de)
 	cp	26
 	ld	(iy+1),#57
-	jr	z,_ld_a_i	;a,i  
+	jr	z,_ld_a_i	;a,i
 	cp	27
 	ld	a,7
-	jr	nz,_ld_b_c	;normaal  
+	jr	nz,_ld_b_c	;normal
 	ld	(iy+1),#5f	;a,r
 _ld_a_i:	ld	(iy),#ed
 	inc	(iy-1)
 	ret
-_ld_a_getal:	ld	hl,(reg2_pointer)	;ld a,getal
+_ld_a_getal:	ld	hl,(reg2_pointer)	;ld a, number
 	call	getalhaakjes
 	ld	a,7
-	jp	c,_ld_b_c	;ld a,getal = normaal  
+	jp	c,_ld_b_c	;ld a,number = normal
 	ld	(iy+1),e
 	ld	(iy+2),d
 	ld	(iy),#3a
@@ -3027,7 +3027,7 @@ _ld_a_getal:	ld	hl,(reg2_pointer)	;ld a,getal
 	ld	a,1
 	jp	vuladresin
 
-_ld_hl:	;ld (hl),r1/getal  
+_ld_hl:	;ld (hl),r1/number
 	call	test2ndregis
 	jr	c,_ld_hl1
 	cp	6
@@ -3037,31 +3037,31 @@ _ld_hl:	;ld (hl),r1/getal
 	or	#70
 	ld	(iy),a
 	ret
-_ld_hl1:	ld	hl,(reg2_pointer)	;ld (hl),getal
+_ld_hl1:	ld	hl,(reg2_pointer)	;ld (hl),number
 	inc	(iy-1)
 	call	getal8bit
 	jp	c,badmnemonic
 	ld	(iy+1),a
 	ld	(iy),#36
 	ret
-_ld_bc1_de1:	;ld (bc)/(de),a  
+_ld_bc1_de1:	;ld (bc)/(de),a
 	call	test2ndregis
 	jp	c,badmnemonic
 	cp	7
 	ret	z
 	jp	badmnemonic
-_ld_getal_re:	;ld (getal),r1  
+_ld_getal_re:	;ld (number),r1
 	ld	(iy-1),3
 	LD	HL,(reg1_pointer)
-	call	getalhaakjes	;is (getal) ?  Ja => DE=getal  
+	call	getalhaakjes	;is (number) ? Yes => DE=number
 	jp	c,badmnemonic
-	push	de	;getal  
+	push	de	;number
 	call	test2ndregis
 	pop	de
 	jp	c,badmnemonic
 	ld	(iy),#32
 	cp	7
-	jr	z,_ld_getal_r1	;,a  
+	jr	z,_ld_getal_r1	;,a
 	ld	(iy),#22
 	cp	12
 	jr	z,_ld_getal_r1	;,hl
@@ -3142,7 +3142,7 @@ _pop:
 	call	testpushpop
 	LD	HL,(reg2_pointer)
 _pop1:
-	ld	de,(reg1_pointer)	;tijdelijke opslag
+	ld	de,(reg1_pointer)	;temporary storage
 	ld	a,(hl)
 	or	a
 	ret	z
@@ -3190,7 +3190,7 @@ testpushpop:
 _pop_cont:
 	ld	(iy),a
 	inc	iy
-	ld	(iy),b	;voor volgende register
+	ld	(iy),b	;for next register
 	inc	(ix-1)
 	ret
 _pop_af:	ld	a,b
@@ -3251,7 +3251,7 @@ _rl1:	ld	b,(iy)
 	ld	a,(iy)
 	cp	3
 	ret	nz
-	ld	(iy-1),4	;bij (ix+ en (iy+ en (ix) en (iy)  
+	ld	(iy-1),4	;at (ix+ and (iy+ and (ix) and (iy))
 	ld	a,(iy+1)
 	ld	(iy),a
 	ld	(iy+1),#cb
@@ -3291,9 +3291,9 @@ _sbc:
 	ld	b,#42
 	jp	_adc_cont
 
-;$$$$$$$$$$ Speciale commando's
+;$$$$$$$$$$ Special commands
 
-;$$$$$ label lengte
+;$$$$$ label length
 _lablen:
 	LD	HL,(reg1_pointer)
 	call	getal8bit
@@ -3367,14 +3367,14 @@ _defw1:
 	ld	de,(Assembladres)
 	inc	de
 	inc	de
-	ld	(Assembladres),de	;schijnverhoging voor $  
+	ld	(Assembladres),de	;mock increase for $
 	ret
 _defw_end:
 	ld	hl,(Assembladre1)
-	ld	(Assembladres),hl	;oude ass. adres
+	ld	(Assembladres),hl	;old ass. address
 	ret
 
-;$$$$$ defs
+;$$$$$defs
 _defs:
 	ld	a,2
 	ld	(Pass),a
@@ -3382,7 +3382,7 @@ _defs:
 	call	getal16bit
 	jp	c,badmnemonic
 	ld	(Lengte_defs),de
-	ld	(iy-1),#ff	;lengte=#ff => defs
+	ld	(iy-1),#ff	;length=#ff => defs
 	xor	a
 	ld	(Vul_defs),a
 	LD	HL,(reg2_pointer)
@@ -3436,17 +3436,17 @@ _defb_tekst:
 	cp	"'"
 	jr	nz,_notekst
 _weltekst:
-	ld	b,a	;" of ' 
+	ld	b,a	;" or '
 	cp	(hl)
-	jr	z,_notekst	;twee quotes--berek-->0
+	jr	z,_notekst	;two quotes--calculate-->0
 _jon_tekst	ld	a,(hl)
 	or	a
-	jr	z,_notekst	;error!?(aanhal. vergeten)
+	jr	z,_notekst	;error!? (quote forgotten)
 	ld	e,a
-	inc	hl	;voorlaatste kar. bereikt?
+	inc	hl	;penultimate car. reaches?
 	ld	a,(hl)
 	cp	b
-	jr	z,schakel_8bit	;zoja,schakel over naar berek.
+	jr	z,schakel_8bit	;if so, switch to calculate.
 	ld	(iy),e
 	inc	iy
 	ld	de,(Assembladres)
@@ -3465,16 +3465,16 @@ _notekst:	pop	af
 
 schakel_8bit	dec	hl
 	dec	hl
-	ld	(hl),b	;plaats beginaanhalingsteken
+	ld	(hl),b	;place quotation mark
 	pop	bc	;clean stack
 	pop	bc
-	scf		;continueer 8bit
+	scf		;continue 8bit
 	ret
 
 ;$$$$$ defc
 _defc:
 	ld	hl,(reg1_pointer)
-	call	testdefb	;VERANDERD!!!!!!!!!!!!!******
+	call	testdefb	;CHANGED!!!!!!!!!!!!!******
 	jp	c,badcommand
 	set	7,(iy-1)
 	ld	hl,(reg2_pointer)
@@ -3671,12 +3671,12 @@ _muluw:
 
 ;$$$$$ org
 _org:
-	call	testrel1	;niet in phase mode
+	call	testrel1	;not in phase mode
 	ld	a,(Macro)
 	or	a
 	ret	nz
 	call	welassembl
-	ret	c	;geen code vanwege if  
+	ret	c	;no code because of if
 	LD	HL,(reg2_pointer)
 	LD	A,(HL)
 	or	a
@@ -3684,18 +3684,18 @@ _org:
 	ld	a,(Pass)
 	push	af
 	ld	a,2
-	ld	(Pass),a	;nu even pass 2
+	ld	(Pass),a	;now pass 2
 	ld	hl,(reg1_pointer)
 	call	getal16bit
 	pop	bc
 	jp	c,badmnemonic
 	ld	(Assembladres),de
-	ld	a,b	;pass  
+	ld	a,b	;pass
 	cp	1
 	ret	z
 	ld	a,(Relocatable)
 	or	a
-	jp	z,_totijdbuf3	;naar ram sturen, want nieuw adres
+	jp	z,_totijdbuf3	;send to ram, because new address
 
 	call	speciallink
 	ld	a,(Segment)
@@ -3703,32 +3703,32 @@ _org:
 	ld	b,6
 	call	putbits
 	ld	de,(Assembladres)
-	jp	putadres	;nieuwe location counter
+	jp	putadres	;new location counter
 
 ;$$$$$ defl
 _defl:
 	ld	a,(Domacro)
 	or	a
-	jp	z,badcommand	;alleen bij macro-aanroep
+	jp	z,badcommand	;only on macro call
 ;$$$$$ equ
 _equ:
 	ld	a,(Pass)
 	dec	a
 	ret	nz
 	call	welassembl
-	ret	c	;geen code vanwege if
+	ret	c	;no code because of if
 	ld	a,(Label)
 	or	a
 	jp	z,badmnemonic
 	ld	a,(Macro)
 	or	a
-	ret	nz	;niet middenin macro definieren
+	ret	nz	;don't define macro in the middle
 	LD	HL,(reg2_pointer)
 	LD	A,(HL)
 	or	a
 	jp	nz,badmnemonic
 	ld	a,2
-	ld	(Pass),a	;nu even pass 2
+	ld	(Pass),a	;now pass 2
 	xor	a
 	ld	(Equ_segment),a
 	ld	hl,(reg1_pointer)
@@ -3738,7 +3738,7 @@ _equ:
 	ld	(Equ_found),a
 	ld	(Equ_adres),de
 	ret
-Equ_segment:	defb	0	;wordt ingevuld door testlabel, pass 2
+Equ_segment:	defb	0	;is filled in by test label, pass 2
 
 ;$$$$$ end
 _end:
@@ -3746,7 +3746,7 @@ _end:
 	or	a
 	ret	nz
 	call	welassembl
-	ret	c	;geen code vanwege if
+	ret	c	;no code because of if
 	ld	a,1
 	ld	(Endcode),a
 	ret
@@ -3778,7 +3778,7 @@ _breakp:
 	ld	a,(Firstbp)
 	or	a
 	ld	hl,#4003
-	call	z,godeb	;wis alle breakpoints
+	call	z,godeb	;clear all breakpoints
 	ld	a,1
 	ld	(Firstbp),a
 	ld	hl,(Assembladres)
@@ -3789,7 +3789,7 @@ godeb:
 	push	hl
 	jp	gotodebugger
 
-Firstbp:	defb	0	;0=1e keer, 1=2e..ne keer
+Firstbp:	defb	0	;0=1st time, 1=2nd..next time
 
 ;$$$$$ tsrhooks
 _tsrhooks:
@@ -3815,11 +3815,11 @@ _cseg:
 	ld	(Assembladres),hl
 	ex	de,hl
 	jp	putadres
-Segment:	defb	0	;Huidige segment: 0=ABS, 1=CSEG, 2=DSEG 
+Segment:	defb	0	;Current segment: 0=ABS, 1=CSEG, 2=DSEG
 Cseg:	defw	0
 Firstcseg:	defw	0
 Csegcomm:	defb	0
-saveoldsegm:	;Ook aangeroepen vanaf begin Codeassemble !!!
+saveoldsegm:	;Also called from beginning Codeassemble !!!
 	ld	a,(Segment)
 	ld	hl,(Assembladres)
 	or	a
@@ -3896,7 +3896,7 @@ savepublic:
 	dec	a
 	jr	nz,_publicpass2
 	ld	de,Label
-savepublic1:	;Aanroep vanuit putlabel !!!
+savepublic1:	;Call from putlabel !!!
 	ld	hl,(Aantalpublic)
 	inc	hl
 	ld	(Aantalpublic),hl
@@ -3925,7 +3925,7 @@ _extrn:
 	call	testrel
 	ld	a,(Pass)
 	dec	a
-	ret	nz	;alleen pass 1
+	ret	nz	;only pass 1
 	ld	hl,(reg1_pointer)
 	call	testoflabel
 	jp	c,badcommand
@@ -3957,8 +3957,8 @@ extrn1:
 	xor	a
 	call	putlabbuffer
 	xor	a
-	call	putlabbuffer	;1e invuladres 0
-	ld	a,%00100000	;Merk external
+	call	putlabbuffer	;1st entry address 0
+	ld	a,%00100000	;Mark external
 	call	putlabbuffer
 	ld	hl,(Aantalextern)
 	inc	hl
@@ -3982,7 +3982,7 @@ Externadres:	defw	0
 testoflabel:
 	call	testfound1
 	ccf
-	ret	c	;1e teken al fout
+	ret	c	;1st character already wrong
 	ld	de,Label
 _testoflab4:
 	push	de
@@ -4016,16 +4016,16 @@ _phase:
 	call	testrel
 	ld	a,(Phase)
 	or	a
-	jp	nz,badcommand	;phase al open
+	jp	nz,badcommand	;phase already open
 	inc	a
 	ld	(Phase),a
 	call	saveoldsegm
 	ld	a,(Segment)
 	ld	(Oldsegment),a
 	xor	a
-	ld	(Segment),a	;simulatie absoluut
+	ld	(Segment),a	;simulation absolute
 	ld	hl,(Assembladres)
-	ld	(Oldaddress),hl	;gemakkelijker voor dephase
+	ld	(Oldaddress),hl	;easier for dephase
 	ld	hl,(reg1_pointer)
 	call	getal16bit
 	jp	c,badcommand
@@ -4042,18 +4042,18 @@ _dephase:
 	call	testrel
 	ld	a,(Phase)
 	or	a
-	jp	z,badcommand	;phase niet geopend
+	jp	z,badcommand	;phase not open
 	dec	a
 	ld	(Phase),a
 	ld	hl,(Assembladres)
 	ld	de,(Phaseaddress)
 	or	a
-	sbc	hl,de	;lengte phase-code
+	sbc	hl,de	;phase code length
 	ex	de,hl
 	ld	a,(Oldsegment)
 	ld	(Segment),a
 	ld	hl,(Oldaddress)
-	add	hl,de	;phase-lengte erbij optellen
+	add	hl,de	;add phase length to it
 	ld	(Assembladres),hl
 	ret
 
@@ -4080,7 +4080,7 @@ _if:
 	ret
 _if2:
 	ld	a,2
-	ld	(Pass),a	;nu even pass 2  
+	ld	(Pass),a	;now pass 2
 	ld	hl,(reg1_pointer)
 	call	doif
 	push	af
@@ -4096,7 +4096,7 @@ _andorfound:
 	push	bc
 	call	doif
 	pop	bc
-	pop	de	;d=eerste 0/1, a=tweede 0/1
+	pop	de	;d=first 0/1, a=second 0/1
 	dec	c
 	jr	z,_do_or
 	and	1
@@ -4108,7 +4108,7 @@ _do_or:
 	or	d
 _einde_if:
 	or	#80
-	ld	hl,(If_adres)	;#81=assembleren, #80=niet ass.
+	ld	hl,(If_adres)	;#81=assemble, #80=not ass.
 	inc	hl
 	bit	7,(hl)
 	jp	nz,toomanyifs
@@ -4197,7 +4197,7 @@ doif:
 	jp	c,gotoifstring
 	ld	(Contifadres),hl
 	pop	bc
-_if3:	pop	hl	;hl=1e, de=2e  
+_if3:	pop	hl	;hl=1st, de=2nd
 	call	testif
 	ld	a,1
 	ret	nc
@@ -4207,10 +4207,10 @@ _if3:	pop	hl	;hl=1e, de=2e
 
 gotoifstring:
 	pop	af
-	pop	af	;2 call's wegwerken
+	pop	af	;get rid of 2 calls
 ifstring:
-	ld	hl,(reg1_pointer)	;bron
-	ld	de,(reg1_pointer)	;doel
+	ld	hl,(reg1_pointer)	;source
+	ld	de,(reg1_pointer)	;target
 	call	teststring
 	jp	c,badcommand
 	ld	(Lengte1),a
@@ -4225,7 +4225,7 @@ ifstring:
 	call	haalteken
 	jp	c,badmnemonic
 	push	af
-	ld	de,(reg2_pointer)	;doel
+	ld	de,(reg2_pointer)	;target
 	call	teststring
 	jp	c,badcommand
 	ld	(Contifadres),hl
@@ -4322,7 +4322,7 @@ teststring:
 	scf
 	ret	nz
 _teststring1:
-	ld	b,a	;" of '
+	ld	b,a	;" or '
 	ld	c,0
 _teststringl:
 	ld	a,(hl)
@@ -4369,7 +4369,7 @@ testgroter:	call	restart20
 	ret		;=  
 testkleiner:	call	restart20
 	ccf
-	ret		;[C] is niet kleiner  
+	ret		;[C] is not smaller
 testkleigrot:	call	testgelijk
 	ccf
 	ret
@@ -4380,11 +4380,11 @@ testgrotgeli:	call	testgelijk
 	ret	z
 	jr	testgroter
 
-If_wacht:	defb	0	;<>0 => n * wachten tot volgende endif  
+If_wacht:	defb	0	;<>0 => n * wait for next endif
 
-	defb	0	;intro if  
-Ifs:	defs	16	;bit7: 1=if bestaat, bit0: 1=assembl.  
-	defb	#ff	;extro if  
+	defb	0	;intro if
+Ifs:	defs	16	;bit7: 1=if exists, bit0: 1=assembl.
+	defb	#ff	;extra if
 If_adres:	defw	Ifs-1
 
 haalteken:
@@ -4427,9 +4427,9 @@ _else:
 	ld	hl,(If_adres)
 	ld	a,(hl)
 	bit	7,a
-	ret	z	;geen if  
+	ret	z	;no if
 	xor	1
-	ld	(hl),a	;draai om  
+	ld	(hl),a	;turn around
 	ret
 
 ;$$$$$ endif
@@ -4448,7 +4448,7 @@ _endif:
 _endif1:	ld	hl,(If_adres)
 	ld	a,(hl)
 	or	a
-	ret	z	;begin buffer
+	ret	z	;start buffer
 	ld	(hl),0
 	dec	hl
 	ld	(If_adres),hl
@@ -4456,9 +4456,9 @@ _endif1:	ld	hl,(If_adres)
 
 ;$$$$$ macro
 
-;MACRO: adres+blok next, label, adres rest, blok rest (soort<>0)
+;MACRO: address+block next, label, address rest, block rest (sort<>0)
 
-Macro:	defb	0	;1=bezig in macro  
+Macro:	defb	0	;1=running macro
 
 _macro:
 	ld	a,(Pass)
@@ -4481,9 +4481,9 @@ _macropass1:
 	xor	a
 	call	putlabbuffer
 	xor	a
-	call	putlabbuffer	;geen waarde
+	call	putlabbuffer	;no value
 	ld	a,1
-	call	putlabbuffer	;soort = macro
+	call	putlabbuffer	;kind = macro
 
 	ld	hl,(reg1_pointer)
 	call	haalmacrolab
@@ -4494,7 +4494,7 @@ _nextmlabel:	call	haalmacrolab
 
 _macro1:
 	ld	a,#ff
-	call	putlabbuffer	;#ff = einde labels
+	call	putlabbuffer	;#ff = end of labels
 	ld	(Macrobufadr),de
 	ld	a,(Labbloknr)
 	ld	(Macrobufblk),a
@@ -4516,7 +4516,7 @@ _macropass2:
 
 
 
-;----- lees macro-label in     UIT: [C]=geen label
+;----- read macro label in     OUT: [C]=no label
 haalmacrojon	inc	hl
 haalmacrolab:
 	ld	a,(hl)
@@ -4524,20 +4524,20 @@ haalmacrolab:
 	scf
 	ret	z
 	cp	9
-	jr	z,haalmacrojon	;kleine bugfix in 1.2.09
+	jr	z,haalmacrojon	;minor bug fix in 1.2.09
 	cp	" "
-	jr	z,haalmacrojon	;kleine bugfix in 1.2.09
+	jr	z,haalmacrojon	;minor bug fix in 1.2.09
 	cp	"@"
-	jp	nz,macrobadcomm	;geen "@"
+	jp	nz,macrobadcomm	;no "@"
 	ld	a,(Labellengte)
 	ld	b,a
 	ld	c,b
 	inc	b
 _nextmacrotk:	ld	a,(hl)
-	;inc     hl               ;grote bugfix in 1.2.09: HL op afsluitzero laten staan!
+	;inc hl ;major bugfix in 1.2.09: leave HL on shutdown zero!
 	or	a
-	jr	z,_mlabelfound	;grote bugfix 1.2.09
-	inc	hl	;grote bugfix 1.2.09
+	jr	z,_mlabelfound	;major bug fix 1.2.09
+	inc	hl	;major bug fix 1.2.09
 	cp	","
 	jr	z,_mlabelfound
 	call	putlabbuffer
@@ -4546,7 +4546,7 @@ _nextmacrotk:	ld	a,(hl)
 _mlabelfound:
 	ld	a,c
 	cp	b
-	jp	z,macrobadcomm	;alleen @  
+	jp	z,macrobadcomm	;alone @
 	xor	a
 	call	putlabbuffer
 	or	a
@@ -4561,7 +4561,7 @@ _endm:
 	ld	(Macro),a
 	ld	a,(Pass)
 	dec	a
-	ret	nz	;alleen pass 1  
+	ret	nz	;only pass 1
 	ld	a,b
 	or	a
 	jp	z,macronotopen
@@ -4569,17 +4569,17 @@ _endm:
 	call	zetlabblok
 	ld	de,(Macrobufadr)
 	ld	a,#ff
-	call	putlabbuffer	;#ff = einde tekst
+	call	putlabbuffer	;#ff = end of text
 	ld	a,(Labbloknr)
-	ld	(Eindlabblok),a	;nieuw einde labelbuffer  
+	ld	(Eindlabblok),a	;new end of label buffer
 	ld	(Eindlabadres),de
 	ret
 
 ;$$$$$ include
 
-Includeram:	defw	0	;oude buffer, regel, lablen, upper
+Includeram:	defw	0	;old buffer, rule, label, upper
 Aantalinclud:	defb	0
-Ramincl:	defs	4*5	;maximum, anders alle buffers vol
+Ramincl:	defs	4*5	;maximum, otherwise all buffers full
 
 
 _include:
@@ -4626,8 +4626,8 @@ _include2:
 	call	berusedadr
 	ld	a,(hl)
 	cp	2
-	jr	c,_include1	;niet laden !
-	call	_totijdbuf3	;wel laden in pass 2of3: buffer1024 versturen want buffer1024 verknoeid bij laden
+	jr	c,_include1	;do not load !
+	call	_totijdbuf3	;did load in pass 2of3: send buffer1024 because buffer1024 messed up on loading
 _include5:
 	ld	hl,(reg2_pointer)
 	inc	hl
@@ -4643,7 +4643,7 @@ _include1:
 	inc	(hl)
 	ld	hl,(Includeram)
 	pop	af
-	ld	(hl),a	;oude buffer
+	ld	(hl),a	;old buffer
 	inc	hl
 	ld	de,(Assemblregel)
 	ld	(hl),e
@@ -4651,7 +4651,7 @@ _include1:
 	ld	(hl),d
 	inc	hl
 	pop	af
-	ld	(hl),a	;labellengte
+	ld	(hl),a	;label length
 	inc	hl
 	pop	af
 	ld	(hl),a	;upper
@@ -4659,7 +4659,7 @@ _include1:
 	ld	(Includeram),hl
 	call	includeini
 	ld	hl,0
-	ld	(Assemblregel),hl	;wordt opgehoogd
+	ld	(Assemblregel),hl	;is increased
 	ret
 
 openadres:
@@ -4966,7 +4966,7 @@ tabS	db	8
 	defw	_rl
 	defb	7,"RL",0,2,#38
 	defw	_rl
-	defb	7,"LL",0,2,#30	;Illegaal commando !!!!!
+	defb	7,"LL",0,2,#30	;Illegal command!!!!!
 	defw	_rl
 tabT	db	1
 	defb	12,"SRHOOKS",0,0,0
@@ -4986,8 +4986,8 @@ tabpunt	db	4
 
 Oudbuffer:	defb	0
 Bufferopen:	defb	0,0,0,0
-Aantalused:	defb	0,0,0,0	;per buffer: aantal keer file include 
-	;ACHTER ELKAAR LATEN STAAN !
+Aantalused:	defb	0,0,0,0	;per buffer: number of times file include
+	;LEAVE BACK TO EACH OTHER !
 
 berusedadr:
 	ld	a,(Sourcebuffer)
@@ -4997,22 +4997,22 @@ berusedadr:
 	add	hl,de
 	ret
 
-;----- Test of standaard: A,B A,C A,D A,E A,H A,L A,(HL) A,A A,(IX+) A,(IY+)
-;                     A,.. 
-;                     UIT: [C]=niet standaard 
+;----- Test or standard: A,B A,C A,D A,E A,H A,L A,(HL) A,A A,(IX+) A,(IY+)
+;                     A,..
+;                     OUT: [C]=non-standard
 
 test_standa1:
 	call	test1stregis
 	ret	c
 	cp	7
 	scf
-	ret	nz	;reg1 <> A  
+	ret	nz	;reg1 <> A
 test_standa6:	call	test2ndregis
 	jp	c,_test_getal
 test_standa5:	cp	24
-	jp	z,test_ix_iy2	;(ix)  
+	jp	z,test_ix_iy2	;(ix)
 	cp	25
-	jp	z,test_ix_iy2	;(iy)  
+	jp	z,test_ix_iy2	;(iy)
 	cp	18
 	jp	nc,test_ixh
 	cp	8
@@ -5020,7 +5020,7 @@ test_standa5:	cp	24
 	cp	9
 	jr	z,test_ix_iy
 	ccf
-	ret	c	;>(iy  
+	ret	c	;>(iy
 	add	a,(iy)
 	ld	(iy),a
 	or	a
@@ -5038,7 +5038,7 @@ _test_ix_iy1:	ex	de,hl
 	ld	(iy-1),3
 	ld	a,(Pass)
 	dec	a
-	ret	z	;Bij pass 1 => terug  
+	ret	z	;At pass 1 => back
 	call	getal8bit
 	ret	c
 	call	testoffset
@@ -5054,7 +5054,7 @@ test_ix_iy2:	ld	b,a
 	ld	a,(iy)
 	add	a,6
 test_standa4:	ld	(iy+1),a
-	ld	(iy+2),0	;(ix) en (iy)
+	ld	(iy+2),0	;(ix) and (iy)
 	ld	(iy-1),3
 	ld	(iy),#dd
 	ld	a,b
@@ -5063,7 +5063,7 @@ test_standa4:	ld	(iy+1),a
 	set	5,(iy)
 	ret
 
-test_ixh:	cp	22	;IXh,IXl,IYh,IYl  
+test_ixh:	cp	22	;IXh,IXl,IYh,IYl
 	ccf
 	ret	c
 	sub	18
@@ -5093,7 +5093,7 @@ _test_getal:
 	or	a
 	ret
 
-;----- kijk of offset niet te groot is   IN: DE=getal  UIT: [C]=te groot 
+;----- check if offset is not too big   IN: DE=number  OUT: [C]=too big
 
 testoffset:
 	ld	a,d
@@ -5106,40 +5106,40 @@ testoffset:
 _testoffset1:	cp	#80
 	ret
 
-;----- Test 1e register      UIT: [C]=geen register, A=nr register (0-..)
+;----- Test 1st register      OUT: [C]=no register, A=num register (0-..)
 
 test1stregis:
 	ld	hl,(reg1_pointer)
 	ld	a,(hl)
 	or	a
 	scf
-	ret	z	;Fout !
+	ret	z	;Wrong !
 	ld	hl,(reg2_pointer)
 	ld	a,(hl)
 	or	a
 	ld	a,7
-	ret	z	;geen reg. 2 => reg. 1 = A
+	ret	z	;no reg. 2 => reg. 1 = A
 
 C666D	ld	hl,(reg1_pointer)
 _testcont:	ld	(Testadres1+1),hl
 	ld	hl,Registers
 	ld	ix,Registers
-	ld	c,0	;nr 0
+	ld	c,0	;num 0
 _test1st_1:
-Testadres1:	ld	de,0	;ingevuld !!!
+Testadres1:	ld	de,0	;filled in !!!
 	ld	a,(hl)
 	or	a
 	scf
-	ret	z	;Niet gevonden !
+	ret	z	;Not found !
 	ld	b,4
 _test1st_5:	ld	a,(de)
 	cp	"a"
 	jr	c,_test1st_4	;<"a"
 	cp	"z"+1
 	jr	nc,_test1st_4	;>"z"
-	and	%11011111	;klein=groot
+	and	%11011111	;small=big
 _test1st_4:	cp	(hl)
-	jr	nz,_test1st_2	;niet gelijk
+	jr	nz,_test1st_2	;not equal
 	or	a
 	ld	a,c
 	ret	z
@@ -5150,7 +5150,7 @@ _test1st_4:	cp	(hl)
 	ret
 _test1st_2:	ld	a,(hl)
 	cp	#ff
-	jr	z,_test1st_6	;(IX en (IY
+	jr	z,_test1st_6	;(IX and (IY
 _test1st_7:	ld	de,4
 	add	ix,de
 	push	ix
@@ -5160,10 +5160,10 @@ _test1st_7:	ld	de,4
 
 _test1st_6:	ld	a,(de)
 	cp	")"
-	jr	z,_test1st_7	;niet (IX+/- of (IY+/-  
+	jr	z,_test1st_7	;not (IX+/- or (IY+/-
 	ld	a,c
 	or	a
-	ret		;(IX+/- of (IY+/-  
+	ret		;(IX+/- or (IY+/-
 
 Registers:	defb	"B",0,0,0,"C",0,0,0,"D",0,0,0,"E",0,0,0	;0-3  
 	defb	"H",0,0,0,"L",0,0,0,"(HL)","A",0,0,0	;4-7  
@@ -5177,7 +5177,7 @@ Registers:	defb	"B",0,0,0,"C",0,0,0,"D",0,0,0,"E",0,0,0	;0-3
 	defb	0
 
 
-	;ok tot hierboven *****************************
+	;ok until above *****************************
 
 
 voorwaarde:
@@ -5188,7 +5188,7 @@ _voorwaarde3:	ld	de,(reg1_pointer)
 	ld	a,(de)
 	and	%11011111
 	cp	(ix)
-	jr	nz,_voorwaarde1	;niet gelijk  
+	jr	nz,_voorwaarde1	;not equal
 	inc	de
 	ld	a,(ix+1)
 	or	a
@@ -5202,7 +5202,7 @@ _voorwaarde1:	inc	ix
 	inc	ix
 	inc	c
 	djnz	_voorwaarde3
-	scf		;niet gevonden
+	scf		;not found
 	ret
 _voorwaarde2:	ld	a,(de)
 	or	a
@@ -5214,7 +5214,7 @@ _voorwaarde2:	ld	a,(de)
 Voorwaarden:	defb	"NZ","Z",0,"NC","C",0,"PO","PE","P",0,"M",0
 
 
-;----- Test 2e register      UIT: [C]=geen register, A=nr register (0-..)
+;----- Test 2nd register      OUT: [C]=no register, A=num register (0-..)
 
 test2ndregis:
 	ld	hl,(reg2_pointer)
@@ -5225,7 +5225,7 @@ test2ndregis:
 	jp	_testcont
 
 
-;--------------- Errors tijdens assembleren !
+;--------------- Errors during assembly !
 
 Badcommand:	defb	"Bad instruction",0
 Getaltegroot:	defb	"Number out of range",0
@@ -5259,7 +5259,7 @@ backerror:
 	ld	a,(Macro)
 	or	a
 backerrormac:
-	call	z,backerror1	;Macro => geen foutmeldingen  
+	call	z,backerror1	;Macro => no error messages
 	ld	hl,(Assembladre1)
 	ld	(Assembladres),hl
 	ld	sp,(Sp_assemble)
@@ -5269,7 +5269,7 @@ backerror1:
 	ld	a,1
 	ld	(Ass_error),a
 	call	welassembl
-	ret	c	;niet assembleren => geen error  
+	ret	c	;do not assemble => no error
 	ld	hl,Aantalerrors
 	inc	(hl)
 	ld	hl,(Erroradres)
@@ -5289,7 +5289,7 @@ backerror1:
 	ld	a,(Assemblregel)
 	out	(#98),a
 	ld	a,(Assemblregel+1)
-	out	(#98),a	;foutadres + regelnummer naar vram  
+	out	(#98),a	;error address + line number to vram
 	ld	a,(Sourcebuffer)
 	out	(#98),a
 	ld	hl,Relcode
@@ -5366,7 +5366,7 @@ _bufferinus1:
 	jp	includeerror
 
 
-;----- foutmeldingen met terugkeer
+;----- error messages with return
 
 labelbestond:
 	ld	de,Labelbestond
@@ -5391,7 +5391,7 @@ labbufvol:
 	ld	bc,22
 	ldir
 	ld	hl,80*Commline+(80-21)/2
-	ld	bc,Kbuf	;labelbuffer vol
+	ld	bc,Kbuf	;label buffer full
 	call	GOtxttocomm
 	call	GObeep
 	call	GOpushanykey
@@ -5404,12 +5404,12 @@ Labelbufvol:	defb	"Labelbuffer too small",0
 
 Sp_labelasse:	defw	0
 Sp_assemble:	defw	0
-Ass_error:	defb	0	;0=geen error, 1=wel  
+Ass_error:	defb	0	;0=no error, 1=yes
 
 
 
 
-;---------- Haal 8 bits getal op  IN: HL=beginadres   UIT: [C]=fout, A=getal
+;---------- Get 8 bit number  IN: HL=start address   OUT: [C]=error, A=number
 
 getal8bit:
 	call	getal16bit
@@ -5421,7 +5421,7 @@ getal8bit:
 	ld	a,e
 	ret
 
-;----- Is getal 16 bits tussen haakjes ?    UIT: [C]=nee, DE=adres
+;----- Is number 16 bits in parentheses ?    OUT: [C]=no, DE=address
 
 getalhaakjes:
 	push	hl
@@ -5444,7 +5444,7 @@ _haakjeback:	pop	hl
 	scf
 	ret
 
-;----- bereken getal 16 bits
+;----- calculate number 16 bits
 
 getal16bit:
 	xor	a
@@ -5452,7 +5452,7 @@ getal16bit:
 	ld	ix,testlabel
 	ld	de,(Assembladres)
 	push	iy
-	ld	a,(Segment)	;voor TSR en Relocatable
+	ld	a,(Segment)	;for TSR and Relocatable
 	rrca
 	rrca
 	call	bergetalasm
@@ -5461,7 +5461,7 @@ getal16bit:
 	ret	nc
 	or	a
 	scf
-	ret	z	;geen getal gevonden 
+	ret	z	;no number found
 	dec	a
 	jp	z,badmnemonic	;1 
 	dec	a
@@ -5469,7 +5469,7 @@ getal16bit:
 	jp	delingdoor0	;3 
 
 
-;----- Bewaar invul-adres bij TSR
+;----- Save entry address with TSR
 
 vuladresin:
 	ld	b,a
@@ -5481,7 +5481,7 @@ vuladresin:
 	jr	nz,vuladresrel
 	ld	a,(Equ_segment)
 	or	a
-	ret	z	;absoluut  
+	ret	z	;absolute
 	ld	a,(Tsr)
 	or	a
 	ret	z
@@ -5527,7 +5527,7 @@ vuladresrel:
 	bit	5,a
 	call	nz,external
 	and	%11000000
-	jr	z,vuladresrel1	;absoluut
+	jr	z,vuladresrel1	;absolute
 	push	iy
 	pop	hl
 	ld	de,jon_len_code
@@ -5549,7 +5549,7 @@ vuladresrel1:
 external:
 	push	af
 	push	bc
-	call	berechtadr	;HL=echte nieuwe adres
+	call	berechtadr	;HL=real new address
 	ld	a,(Externalblk)
 	call	zetlabblok
 	ld	de,(Externaladr)
@@ -5560,7 +5560,7 @@ external:
 	ld	a,(Segment)
 	rrca
 	rrca
-	or	%00100000	;kenmerk: external
+	or	%00100000	;characteristic: external
 	call	putlabbuffer
 	pop	bc
 	pop	af
@@ -5583,7 +5583,7 @@ berechtadr:
 	ret
 
 
-;----- is label ? voor berekengetal/calculator
+;----- is label ? for calculation number/calculator
 
 testlabel1:
 	push	hl
@@ -5605,11 +5605,11 @@ _testlab1_4:	push	bc
 _testfout:
 	pop	hl
 	scf
-	ret		;te lang
+	ret		;too long
 _testlab1_3:	xor	a
 	ld	(de),a
 	ld	hl,Label
-	call	labelcorrect	;test of goed label  
+	call	labelcorrect	;test for good label
 	jr	c,_testfout
 	xor	a
 	ld	hl,Label
@@ -5620,8 +5620,8 @@ _testlab1_3:	xor	a
 	ex	de,hl
 	call	zetlabblok
 	call	getlabbuffer
-	call	getlabbuffer	;+next adres 
-	call	getlabbuffer	;+next blok
+	call	getlabbuffer	;+next address
+	call	getlabbuffer	;+next block
 _testlab1_1:	call	getlabbuffer
 	and	%10000000
 	jr	z,_testlab1_1
@@ -5634,14 +5634,14 @@ _testlab1_1:	call	getlabbuffer
 ;              ld      (Extrnadres),de
 	call	getlabbuffer
 	ex	de,hl
-	pop	hl	;de=getal
+	pop	hl	;de=number
 	and	1
 	jr	nz,_testfout	;=macro
 	ld	bc,Label
 	or	a
 	sbc	hl,bc
 	pop	bc
-	add	hl,bc	;volgend adres
+	add	hl,bc	;next address
 	or	a
 	ret
 Labsoort:	defb	0
@@ -5669,30 +5669,30 @@ _testlab3:	xor	a
 	ld	(de),a
 
 	ld	hl,Label
-	call	labelcorrect	;test of goed label 
+	call	labelcorrect	;test for good label
 	pop	hl
-	ret	c	;label too long is al getest 
+	ret	c	;label too long has already been tested
 	ld	a,(Pass)
 	dec	a
 	jr	z,_testlab2
 	ld	a,(Macro)
 	or	a
-	jr	nz,_testlab2	;bij macro's niet testen 
+	jr	nz,_testlab2	;do not test with macros
 	call	welassembl
-	jr	c,_testlab2	;als assembleren uit => niet testen 
+	jr	c,_testlab2	;if assemble off => don't test
 
 	push	hl
 	xor	a
 	ld	hl,Label
 	call	labelexist
-	jp	c,labelnotdefi	;bestaat niet 
+	jp	c,labelnotdefi	;does not exist
 
 	push	de
 	ex	de,hl
 	call	zetlabblok
 	call	getlabbuffer
-	call	getlabbuffer	;+next adres
-	call	getlabbuffer	;+next blok
+	call	getlabbuffer	;+next address
+	call	getlabbuffer	;+next block
 _testlab1:	call	getlabbuffer
 	and	%10000000
 	jr	z,_testlab1
@@ -5711,17 +5711,17 @@ _testlab1:	call	getlabbuffer
 ;              ld      a,(Equ_segment)
 ;              or      b
 ;              ld      (Equ_segment),a
-	ex	de,hl	;de=getal 
+	ex	de,hl	;de=number
 	pop	hl
 	ld	bc,Label
 	or	a
 	sbc	hl,bc
 	pop	bc
-	add	hl,bc	;volgend adres 
-Segmentback:	ld	a,0	;INGEVULD !!!
+	add	hl,bc	;next address
+Segmentback:	ld	a,0	;FILLED IN !!!
 	or	a
 	ret
-_testlab2:	;Pass 1 
+_testlab2:	;Pass 1
 	ld	a,(Labellengte)
 	inc	a
 	ld	b,a
@@ -5734,13 +5734,13 @@ _testlab2_2:	push	bc
 	call	welassembl
 	jp	nc,labeltoolon1
 _testlab2_1:
-	ld	de,1	;getal 1 
+	ld	de,1	;number 1
 	or	a
 	ret
 
 
 
-;------ Print 18 errors op scherm
+;------ Print 18 errors on screen
 
 prterrlines:
 	ld	b,18
@@ -5762,7 +5762,7 @@ _nextwis:	ld	a,0
 	inc	ix
 	ld	b,(ix)
 	inc	ix
-	ld	h,#80	;geen vram-adres
+	ld	h,#80	;no vram address
 	call	printtekst
 	ld	bc,Inline
 	ld	h,#80
@@ -5771,15 +5771,15 @@ _nextwis:	ld	a,0
 	inc	ix
 	ld	d,(ix)
 	inc	ix
-	ld	b,5+128	;bit 7:geen voorloopnullen
-	ld	h,#80	;LATEN !
+	ld	b,5+128	;bit 7: no leading zeros
+	ld	h,#80	;TO LEAVE !
 	call	printdecimaa
 	ld	a,(ix)
 	inc	ix
 	add	a,"0"
 	ld	(Inbuf+2),a
 	ld	bc,Inbuf
-	ld	h,#80	;LATEN ! 
+	ld	h,#80	;TO LEAVE !
 	call	printtekst
 	pop	af
 	inc	a
@@ -5794,7 +5794,7 @@ _cntprt:
 Inline:	defb	" in line ",0
 Inbuf:	defb	" [ ]",0
 
-;---------- Algemene subroutines
+;---------- General subroutines
 
 
 restart20:	ld	a,h
@@ -5808,15 +5808,15 @@ savedisk:
 	push	iy
 	ld	de,(Used_fcb)
 	ld	c,#26
-	call	bdos	;tussentijds saven
+	call	bdos	;interim save
 	pop	iy
 	or	a
 	ret	z
 	ld	ix,(Foutadres)
 	jp	(ix)
 
-;----- 1 byte naar labelbuffer + eventueel: verhoog buffer
-;----- IN: DE=adres
+;----- 1 byte to label buffer + optionally: increase buffer
+;----- IN: DE=address
 
 putlabbuffer:
 	ld	(de),a
@@ -5841,8 +5841,8 @@ _putlabbuff1:
 	pop	af
 	jp	labbufvol
 
-;----- 1 byte van labelbuffer + verhoog bufferblok indien nodig
-;----- IN: DE=adres
+;----- 1 byte of label buffer + increase buffer block if necessary
+;----- IN: DE=address
 getlabbuffer:
 	ld	a,(de)
 	inc	de
@@ -5853,7 +5853,7 @@ getlabbuffer:
 	ld	hl,Labbloknr
 	ld	a,(Aantallabelb)
 	cp	(hl)
-	jr	z,_getlabbuff1	;textbuffer vol 
+	jr	z,_getlabbuff1	;text buffer full
 	inc	(hl)
 	ld	a,(hl)
 	call	zetlabblok
@@ -5862,8 +5862,8 @@ _getlabbuff1:	pop	hl
 	res	6,d
 	ret
 
-;----- IN: A = Blocknr van tekstbuffer (1-..)
-;----- Verandert: AF
+;----- IN: A = Block number of text buffer (1-..)
+;----- Changes: AF
 
 zettextblok:
 	ld	(Textbloknr),a
@@ -5884,8 +5884,8 @@ _zettextblo1:
 	pop	hl
 	ret
 
-;----- IN: A = Blocknr van labelbuffer (1-..)
-;----- Verandert: AF
+;----- IN: A = Block number of label buffer (1-..)
+;----- Changes: AF
 
 zetlabblok:
 	ld	(Labbloknr),a
@@ -5906,8 +5906,8 @@ _zetlabblo1:
 	pop	hl
 	ret
 
-;----- IN: A = Blocknr van databuffer (1-..)
-;----- Verandert: AF
+;----- IN: A = Block number of data buffer (1-..)
+;----- Changes: AF
 
 zetdatablok:
 	ld	(Databloknr),a
@@ -5929,28 +5929,28 @@ _zetdatablo1:
 	ret
 
 ;####################################
-;Geef adres bij regel   IN: DE=regel
-;UIT: [C]=einde tekst, DE=adres text, A=hoev. textblok
-;Verandert: HL,DE,AF,BC
+;Enter address at line   IN: DE=line
+;OUT: [C]=end text, DE=address text, A=quantity. text block
+;Changes: HL,DE,AF,BC
 
 geefadrregel:
-;IN : DE=regelnummer
-;UIT: DE=adres databuffer, C=hoeveelste blok databuffer
+;IN : DE=line number
+;OUT: DE=address data buffer, C=how many block of data buffer
 	dec	de
 	ld	l,e
 	ld	h,d
 	ld	a,#80
-	add	hl,hl	;geeft nooit carry (regel=<32768)
-	add	hl,de	;dit ev. wel(pas vanaf rond regel 22000)
-	jr	c,vulamet1	;is snelst (niet met jr nc,_vulamet1)
+	add	hl,hl	;never returns carry (line=<32768)
+	add	hl,de	;this is possible (only from around line 22000)
+	jr	c,vulamet1	;is fastest (not with jr nc,_vulamet1)
 _vulamet1	sla	h
-	rla		;                ;ook bit x naar CF!
-	rl	h	;bit x naar bit 0 van h
+	rla		;                  ;also bit x to CF!
+	rl	h	;bit x to bit 0 of h
 	rla
-	inc	a	;van 1..6 ipv 0..5
+	inc	a	;from 1..6 instead of 0..5
 	ld	c,a
-	srl	h	;bit x naar CF
-	rr	h	;bit x naar pos. 7 (=adres #8000...)
+	srl	h	;bit x to CF
+	rr	h	;bit x to pos. 7 (=address #8000...)
 	ex	de,hl
 	ld	a,c
 	call	zetdatablok
@@ -5970,8 +5970,8 @@ _vulamet1	sla	h
 vulamet1	inc	a
 	jr	_vulamet1
 
-;----- 1 byte van databuffer + verhoog bufferblok indien nodig
-;----- IN: DE=adres
+;----- 1 byte of data buffer + increase buffer block if necessary
+;----- IN: DE=address
 getdatbuffer:
 	ld	a,(de)
 	inc	de
@@ -5982,7 +5982,7 @@ getdatbuffer:
 	ld	hl,Databloknr
 	ld	a,(Aantaldatabl)
 	cp	(hl)
-	jr	z,_getdatbuff1	;databuffer vol  
+	jr	z,_getdatbuff1	;data buffer full
 	inc	(hl)
 	ld	a,(hl)
 	call	zetdatablok
@@ -5991,8 +5991,8 @@ _getdatbuff1:	pop	hl
 	res	6,d
 	ret
 
-;----- 1 byte van textbuffer + verhoog bufferblok indien nodig
-;----- IN: DE=adres
+;----- 1 byte of textbuffer + increase buffer block if necessary
+;----- IN: DE=address
 gettxtbuffer:
 	ld	a,(de)
 	inc	de
@@ -6003,7 +6003,7 @@ gettxtbuffer:
 	ld	hl,Textbloknr
 	ld	a,(Aantaltextbl)
 	cp	(hl)
-	jr	z,_gettxtbuff1	;textbuffer vol
+	jr	z,_gettxtbuff1	;text buffer full
 	inc	(hl)
 	ld	a,(hl)
 	call	zettextblok
@@ -6020,12 +6020,12 @@ reg2_pointer	dw	0
 
 Buffer1:
 Zin:	defs	256+64,0
-Label:	equ	Zin+161	;30 tekens + 0
-Commando:	equ	Label+31	;opslag commando+registers
+Label:	equ	Zin+161	;30 characters + 0
+Commando:	equ	Label+31	;store command+registers
 
 	ds	#7000-$,#c9
 
-;!!!!!!!!!!!!!!!!!!!!!!!!! Dubbel gebruikte variabelen/adressen
+;!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Duplicate variables/addresses
 
 Doubleuse:
 

--- a/Compass129Sources/DATfile/DEBUG127.ASC
+++ b/Compass129Sources/DATfile/DEBUG127.ASC
@@ -12,7 +12,7 @@ right	equ	28
 left	equ	29
 up	equ	30
 down	equ	31
-stop	equ	250	; speciaal aangepast door getkey
+stop	equ	250	; specially patched by getkey
 
 startcursorad	equ	#0000
 startmonadres	equ	#c000
@@ -136,7 +136,7 @@ setgetwrite	ld	(hl),c
 	cp	6
 	ret	nz
 	inc	hl
-	ld	(hl),c	;ook zetten op disoptabpc
+	ld	(hl),c	;also put on disoptabpc
 	inc	hl
 	ld	(hl),b
 	ld	a,1
@@ -172,8 +172,8 @@ init	ld	(intreesp),sp
 	ld	(subslotregs+2),hl
 nospload	call	updatesubslot
 	ld	hl,realfkeys
-	ld	de,#f87f	; adres waar functie toetsen opslag begint
-	ld	bc,5*256	; c juist voor adjust-rout
+	ld	de,#f87f	; address where function keys storage begins
+	ld	bc,5*256	; c just before adjust route
 _adjustfkey	dec	c
 	ld	a,(de)
 	ld	(hl),a
@@ -187,7 +187,7 @@ _adjustfkey	dec	c
 	xor	a
 	ld	(de),a
 	ld	a,e
-	add	a,15	; 16 bytes per f-key en reeds 1 inc de
+	add	a,15	; 16 bytes per f-key and already 1 inc de
 	ld	e,a
 	ld	a,0
 	adc	a,d
@@ -207,7 +207,7 @@ init1	ld	(turbor),a
 	call	scherminit
 	jp	hoofdlus
 
-eerstekeer	db	0	;0=eerstekeer
+eerstekeer	db	0	;0=first time
 reg_sp_init	dw	0
 
 scherminit	call	stackinit
@@ -257,7 +257,7 @@ hoofdbalk	db	23,23,23,23,23," SYSTEM ",23,23,23,23
 	db	23,23," BREAKPOINTS ",23,23,23,23,0
 
 titelbalk	db	"Disassembler/Debugger",0
-; functie toetsen produceren code ff,fe,fd,fc,fd
+; function keys produce code ff,fe,fd,fc,fd
 hoofdlus	call	regafbeeld
 	call	slotmonitor
 hoofdlusbis	call	monitor
@@ -327,12 +327,12 @@ hoofdlusactie3	inc	hl
 MKLIST	macro	@toets,@routine
 	db	@toets
 	dw	@routine
-	db	@toets-64	;voor CTRL
+	db	@toets-64	;for CTRL
 	dw	@routine
 	endm
 
-; opmerking vervang hier " door ' en we krijgen fouten
-; GEN80 verliest bij parameterbinding een aanhalingsteken onderweg
+; comment replace " with ' here and we get errors
+; GEN80 loses quotes on parameter binding
 hfdlusactitab	MKLIST	"A",getdisamadres
 	MKLIST	"B",routnewbreak
 	MKLIST	"C",CALCULATOR
@@ -461,7 +461,7 @@ toquit	call	zetkader
 	ld	hl,comline*80+27
 	call	PRINTTEKST
 	call	GETKEY
-	and	#df	;verschil hoofdletter/kleineletter
+	and	#df	;difference uppercase/lowercase
 	cp	"Y"
 	jr	z,toquit6
 	jp	buf2screen
@@ -470,7 +470,7 @@ shiftesc:	ld	a,4
 toquit6	xor	a
 restorefkey	push	af
 	ld	de,realfkeys
-	ld	hl,#f87f	; adres waar functie toetsen opslag begint
+	ld	hl,#f87f	; address where function keys storage begins
 	ld	b,5
 restorefkey1	ld	a,(de)
 	ld	(hl),a
@@ -770,8 +770,8 @@ getslotindeel1	rrca
 	jr	c,getslotindeel2
 	pop	bc
 	ld	a,b
-	jp	getslotinddeel4	; a opslaan in hl
-getslotindeel2	ld	a,(hl)	; hier opvragen van subslot
+	jp	getslotinddeel4	; a save in hl
+getslotindeel2	ld	a,(hl)	; request subslot here
 	rra
 	rra
 	and	3
@@ -792,7 +792,7 @@ getslotinddeel3	pop	bc
 	or	128
 getslotinddeel4	pop	hl
 	ld	(hl),a
-; aanpassen subslotregister indien nodig
+; adjust subslot register if necessary
 	bit	7,a
 	jp	z,getslotsubniet
 	push	hl
@@ -814,7 +814,7 @@ getslotinddeel5	rrca
 	or	c
 	ld	(hl),a
 	pop	hl
-; nog ophalen van de memmappage
+; still picking up the memmappage
 getslotsubniet	inc	hl
 	push	hl
 	ld	bc,getslotindtxt4
@@ -937,7 +937,7 @@ routprint1	ld	hl,(bufferhoofdpr)
 	ld	de,20
 	add	hl,de
 	ld	(waarbuffer),hl
-	ld	hl,codebuffer	;de vierbytesbuffer
+	ld	hl,codebuffer	;the four-byte buffer
 	ld	a,(lenghtcode)
 	ld	c,a
 	ld	b,4
@@ -1091,7 +1091,7 @@ _puldown43	cp	1
 
 _puldown44	and	255-32
 	jr	nz,_puldown4
-	; indien c=1 -> toevoegen i/o , c=2 ->kiezen +wissen
+	; if c=1 -> add i/o , c=2 -> select + delete
 	ld	a,c
 	dec	a
 	jr	z,puldown4inv
@@ -1177,7 +1177,7 @@ puldw4sort2	ld	e,(hl)
 _pulldown4	call	buf2screen
 	jp	pulldown4
 
-puldown4ch1	db	0,6	; berpekte info-tabel nodig voor Kiesoptie
+puldown4ch1	db	0,6	; limited info table needed for Select option
 puldown4menu	db	3,6,0
 	db	"insert"
 	db	"delete"
@@ -1251,7 +1251,7 @@ puldown1menu	db	8,13,0
 	db	"Quit       ^Q"
 
 puldown2menu	db	4,18,0
-	db	"CPU: Z80          "	; off,rom,dram in volgorde
+	db	"CPU: Z80          "	; off,rom,dram in order
 	db	"MSX rst: yes      "
 linktekst	db	"Linking off     ^L",0
 	db	"Linked: cursor  ^L",0
@@ -1268,7 +1268,7 @@ txtr800	db	"Z80      ",0
 puldown3menu	db	8,19,0
 puldown3menu4	db	"Debugger address ^A"
 puldown3menu3	db	"Monitor address  ^M"
-puldown3menu1	db	"Go                 "	; zie ook: goadres
+puldown3menu1	db	"Go                 "	; see also: goadres
 	db	"Registers        ^R"
 puldown3menu2	db	"Temporary          "
 	db	"Return           ^U"
@@ -1357,7 +1357,7 @@ routtotxtbuf	call	zet_start_end
 	LD	(printstart),hl
 	LD	(printstop),de
 	LD	(reg_pcvdis),hl
-	ld	a,#c3	; begin afbuigingen
+	ld	a,#c3	; start deflections
 	ld	(atobuffer),a
 	ld	(hltobuffer),a
 	ld	hl,totxthl
@@ -1370,12 +1370,12 @@ routtotxtbuf	call	zet_start_end
 	ld	(labelpoint),hl
 	ld	a,1
 	ld	(totxt_labblok),A
-;pas 1 voor opslag labels
-; hlopslag : 0 geen 16bits geprint anders wel
-; labelpoint :BEGIN WIJST NAAR LAATSTE BYTE PROGRAMMA TO MAX #8000
+;pass 1 for storage labels
+; hl storage : 0 no 16bits printed otherwise yes
+; labelpoint :BEGIN POINTS TO LAST BYTE PROGRAM TO MAX #8000
 ;
 totxtlabel	call	knipper
-	xor	a	; resetten byte of 16bits geplaatstis
+	xor	a	; reset byte or 16bit is inserted
 	ld	(hlopslag),a
 	ld	de,(bufferhoofdpr)
 	ld	(waarbuffer),de
@@ -1512,7 +1512,7 @@ routtotxt10	ld	a," "
 	push	hl
 	ex	de,hl
 	ld	a,1
-	call	LINETOASSEMB	; check hier niet op carry,komt nog tweede
+	call	LINETOASSEMB	; don't check here on carry, comes second
 	pop	hl
 	dec	hl
 	dec	hl
@@ -1532,7 +1532,7 @@ routtotxt18	ex	de,hl
 	call	LINETOASSEMB
 	jr	routtotxt41
 
-routtotxt19	ld	a,'>'	; kijken of er pijl naar adres staat  ;*
+routtotxt19	ld	a,'>'	; check if there is an arrow to address ;*
 	ld	b,40
 routtotxt2	inc	hl
 	cp	(hl)
@@ -1570,13 +1570,13 @@ routtotxt6	ld	hl,80*9+25
 	ld	ix,transferermenu
 	call	PUTMENU
 
-; einde: herstellen afbuigingen
+; end: fix deflections
 routtotxtend	call	transferempty
 	ld	de,(bufferhoofdpr)
 	ld	hl,txt_end
 	ld	bc,5
 	ldir
-	ld	a,2	;beeindigen
+	ld	a,2	;to end
 	call	transfer
 	ld	hl,0
 	ld	(atobuffer),hl
@@ -1635,7 +1635,7 @@ totxta	push	af
 idhexvoor	ld	a,"#"
 	jp	ascitobuffer
 
-tolabelhl	push	ix	; afbuigen om labels te printen als het er een is
+tolabelhl	push	ix	; deflect to print labels if it has one
 	push	de
 	call	ishllabel
 	pop	de
@@ -1707,9 +1707,9 @@ ishllabel_hl	dw	0
 savelabbufnr	db	0
 savelabbufad	dw	0
 
-;geeft label-id. J,C of D (in volgorde van belangrijkheid)
-; terug A bevat ascii v/d ID
-; wijzigt : af
+;returns label id. J,C or D (in order of importance)
+; back A contains ascii v/d ID
+; changes : af
 labelid	ld	a,(codebuffer)
 	cp	#c3	; jp
 	jp	z,labelidj
@@ -1742,7 +1742,7 @@ callbufpoint	dw	callbuf-1
 callbuf	ds	3*9
 callbufend	equ	$
 
-getadres	push	ix	; inkom [c] dan hexprinthl
+getadres	push	ix	; input [c] then hexprinthl
 	push	hl
 	push	af
 	ld	hl,80*5+30
@@ -1953,7 +1953,7 @@ mainbreakfulq	ld	a,(breakbufpoint)
 	scf
 	ret
 
-insertbreak	call	mainbreakfulq	;toevoegen bkp, in HL
+insertbreak	call	mainbreakfulq	;add bkp, in HL
 	ret	c
 
 mainbreaknew	call	ishlbreakpoint
@@ -2022,7 +2022,7 @@ _delbreak4	ld	a,(de)
 	jr	nz,_delbreak3
 
 	ld	hl,breakbufend
-	sbc	hl,de	;Carry is nog nul
+	sbc	hl,de	;Carry is still zero
 	ld	b,h
 	ld	c,l
 	ld	h,d
@@ -2055,14 +2055,14 @@ bpverandert2	ld	(de),a
 	djnz	bpverandert1
 	jp	distoscr
 
-; IN :HL  OUT:NC=hl geen breakpoint Verandert:C,DE,AF
+; IN :HL  OUT:NC=hl no breakpoint Changes:C,DE,AF
 ishlbreakpoint	ld	de,breakbuf
 	ld	a,(breakbufpoint)
 	ld	c,a
 _ishlbreak1	ld	a,c
 	cp	e
 	scf
-	ret	z	;einde bereikt
+	ret	z	;end reached
 	ld	a,(de)
 	inc	de
 	cp	l
@@ -2071,7 +2071,7 @@ _ishlbreak1	ld	a,c
 	jr	_ishlbreak1
 _ishlbreak2	ld	a,(de)
 	cp	h
-	ret	z	;gevonden!
+	ret	z	;found it!
 	inc	de
 	jr	_ishlbreak1
 
@@ -2142,7 +2142,7 @@ viewbreak4	inc	hl
 	xor	a
 	jp	routdelbreak1
 
-breakbufpoint	dw	breakbuf	;verwijzing naar eerste VRIJE entry
+breakbufpoint	dw	breakbuf	;reference to first FREE entry
 breakbuf	ds	2*15
 breakbufend	equ	$
 breakvalsopt	db	0
@@ -2153,16 +2153,16 @@ breakvalsmenu	db	0,4,0
 stackviewx	equ	73
 stackviewy	equ	3
 stackaantlijn	equ	19
-	; init routine om kader op het scherm te plaatsen
-stackinit	ld	hl,stackviewy*80+stackviewx	; eerst opbouw schermkader
+	; init routine to put frame on screen
+stackinit	ld	hl,stackviewy*80+stackviewx	; first structure screen frame
 	ld	bc,stackuplijn1
-	call	PRINTTEKST	; bovenste lijn
+	call	PRINTTEKST	; top line
 	ld	hl,stackviewy*80+stackviewx+80
-	inc	bc	;=ld bc,stackuplijn2
-	call	PRINTTEKST	; bovenste lijn
+	inc	bc	;=ld bc,stackupline2
+	call	PRINTTEKST	; top line
 	ld	hl,stackviewy*80+stackviewx+160
-	inc	bc	;=ld bc,stackuplijn3
-	call	PRINTTEKST	; bovenste lijn
+	inc	bc	;=ld bc,stackupline3
+	call	PRINTTEKST	; top line
 	ld	hl,stackviewy*80+stackviewx+240
 	ld	de,80
 	exx
@@ -2175,8 +2175,8 @@ _stackinit1	exx
 	exx
 	djnz	_stackinit1
 	exx
-	inc	bc	;=ld bc,stackdownlijn
-	jp	PRINTTEKST	; onderste lijn
+	inc	bc	;=ld bc,stackdown line
+	jp	PRINTTEKST	; bottom line
 
 stackuplijn1	db	18,23,23,23,23,23,25,0
 stackuplijn2	db	22,83,84,65,67,75,22,0
@@ -2184,7 +2184,7 @@ stackuplijn3	db	20,23,23,23,23,23,19,0
 stackleeglijn	db	22,32,32,32,32,32,22,0
 stackdownlijn	db	17,23,23,23,23,23,27,0
 
-;  volgende routine is nodig om het kader up-to-date te houden
+; following routine is needed to keep the frame up to date
 stackvupdate	ld	hl,(reg_sp)
 	ld	bc,stackaantlijn*2
 	call	GETFROMRAM
@@ -2234,7 +2234,7 @@ _regtoscr	ld	e,(hl)
 	inc	hl
 	ld	h,(hl)
 	ld	l,a
-	call	hltobuffer	; dit is zonder #
+	call	hltobuffer	; this is without #
 	ex	de,hl
 	djnz	_regtoscr
 
@@ -2246,7 +2246,7 @@ _regtoscr	ld	e,(hl)
 	sla	e
 	call	_regflag
 
-	ld	bc,#204E	; SPATIE N
+	ld	bc,#204E	; SPACE N
 	ld	hl,regzflag
 	sla	e
 	call	_regflag
@@ -2268,7 +2268,7 @@ _regtoscr	ld	e,(hl)
 	sla	e
 	call	_regflag
 
-	ld	bc,#204E	; SPATIE N
+	ld	bc,#204E	; SPACE N
 	ld	hl,regcflag
 	sla	e
 	call	_regflag
@@ -2287,13 +2287,13 @@ scrreg	equ	regviewx*16+regviewy
 	ld	b,9
 	jp	_toscr
 
-_regflag	ld	a,c	; NC dan reg c tonen else b
+_regflag	ld	a,c	; NC then reg to c show else b
 	jr	nc,_regflag1
 	ld	a,b
 _regflag1	ld	(hl),a
 	ret
 
-regscrpoint	; eerst waarbuffer dan welk register dan vramadres
+regscrpoint	; first where buffer then which register then vram address
 	dw	regscraf+5,reg_af,(1+regviewx)*256+regviewy+1
 	dw	regscraf+16,reg_bc,(12+regviewx)*256+regviewy+1
 	dw	regscraf+28,reg_de,(24+regviewx)*256+regviewy+1
@@ -2334,7 +2334,7 @@ regend	db	23,23,23,23,23,23,23,23,23,23,23,23
 	db	23,23,23,23,23,23,23,23,23,23,23,23,23
 	db	23,23,23,23,23,23,23,23,0
 
-regaanpas	ld	c,1	; c=pointer welke reg(max 12, IR+diei=13)
+regaanpas	ld	c,1	; c=pointer which reg(max 12, IR+diei=13)
 	ld	a,29
 	jr	regaanpas1
 regaanpas0	call	CHRGET
@@ -2532,13 +2532,13 @@ flagaanpas8	ld	b,0
 	pop	bc
 	jp	flagaanpas0
 
-flagtab	db	%01000000	; zerro
+flagtab	db	%01000000	; zero
 	db	%00000001	; carry
 	db	%00000010	; n
 	db	%00000100	; po
 	db	%00010000	; h
 	db	%10000000	; s
-; volgorde van flagtab in zelfde volgorde als afbeelden op scherm
+; order of flag tab in same order as display on screen
 
 resregaanpas	push	bc
 	ld	b,7
@@ -2569,7 +2569,7 @@ ispconmon	ld	b,0
 	call	hlgelijkde
 	rl	b	; if monadres<=reg_pc then b=0 else b=1
 	ld	hl,(aantalmonlijn-1)*8
-; ADD HL,DE IS OPGESPLITST OM RONDLOPEN TE BEMERKEN
+; ADD HL,DE IS SPLIT TO NOTICE WALK AROUND
 	ld	a,l
 	add	a,e
 	ld	e,a
@@ -2587,7 +2587,7 @@ ispconmon	ld	b,0
 	cp	%11
 	jp	z,wismonbalk
 	jr	ispconmon3
-ispconmon0	or	a	; zal zerro als pc binnen grenzen
+ispconmon0	or	a	; will zero as pc within limits
 	jp	nz,wismonbalk
 
 ispconmon3	call	wismonbalk
@@ -2595,7 +2595,7 @@ ispconmon3	call	wismonbalk
 	ld	de,(monadres)
 	or	a
 	sbc	hl,de
-	ld	a,l	;l=%yyyyyxxx y-lijn x'de charakter
+	ld	a,l	;l=%yyyyyxxx y-line x'th character
 	rrca
 	rrca
 	rrca
@@ -2621,7 +2621,7 @@ ispconmon1	ld	h,a
 
 wismonbalk	ld	a,(monybalk)
 	ld	l,a
-	ld	h,40	; wist balk op monitor
+	ld	h,40	; clears bar on monitor
 	ld	b,33
 	jp	WISBALK
 
@@ -2632,12 +2632,12 @@ monitor	ld	a,(monlinkyesno)
 	jr	nz,monitor0
 	ld	a,(aanduiddisam)
 	or	a
-	jr	z,monitor7	; bij nul geen pijl zichtbaar
+	jr	z,monitor7	; at zero no arrow visible
 	call	adresnapijl
 	jr	monitor1
 monitor0	ld	a,(aanduidtrace)
 	or	a
-	jr	z,monitor7	; bij nul geen balk zichtbaar
+	jr	z,monitor7	; at zero no bar visible
 	ld	de,(reg_pc)
 monitor1	ld	hl,7
 	call	hlgelijkde
@@ -2653,14 +2653,14 @@ monitor5	ld	hl,(monadres)
 	ld	bc,8
 	add	hl,bc
 	call	hlgelijkde
-	jr	c,monitor6	; C=> monadres+8<disoptabpc
+	jr	c,monitor6	; C=> monaddress+8<disoptabpc
 	ld	hl,(monadres)
 	ld	a,h
 	or	l
 	jr	z,monitor65
 	ld	bc,-7
 	dec	hl
-	call	hlgelijkde	; C=> monadres-1<disop
+	call	hlgelijkde	; C=> monaddress-1<disop
 	jr	c,monitor65
 	add	hl,bc
 monitor6	ld	(monadres),hl
@@ -2757,7 +2757,7 @@ slotmonitor4	ld	a,(de)
 	call	ascitobuffer
 	call	ascitobuffer
 	djnz	slotmonitor4
-	ld	hl,slotkadergeg+6	;plaatsen subslotregs
+	ld	hl,slotkadergeg+6	;place subslot regs
 	ld	de,subslotregs+3
 	ld	a,8
 slotmonitor5	ld	b,a
@@ -2814,11 +2814,11 @@ downlijn	db	26,23,23,23,23,23,23,17,23,23,23,23,23,23,23,23,23
 	db	23,23,23,23,23,23,23,23,23,23,23,17,23,23,23,23,23
 	db	23,23,23,23,23,17,0
 
-bufferhoofdpr	dw	0	;omwille GETFROMRAM
+bufferhoofdpr	dw	0	;because of GETFROMRAM
 
-reg_pcvdis	dw	0	; pc register voor volgende instr
+reg_pcvdis	dw	0	; pc register for next instr
 
-;disoppoint       db      0  ;GEEFT HOEVEELSTE POINTERVAN DISOPTAB niet gebruikt?*********
+;disoppoint      db 0 ;GIVES MANY POINTER OF DISOPTAB not used?*********
 
 monitorbuf	db	"   Minimonitor-address :   ADAD  ",0
 	db	"                                 ",0
@@ -2830,21 +2830,21 @@ monitorbuf	db	"   Minimonitor-address :   ADAD  ",0
 	db	"                                 ",0
 	db	"                                 ",0
 	db	"                                 ",0
-monybalk	db	7	; niet op nul anders hoofdbalk beschadigen
-	; bij eerste aanroep wismonbalk in hoofdlus
+monybalk	db	7	; not to zero otherwise damage main bar
+	;on first call erase bar in main loop
 aantalmonlijn	equ	9
 monadres	dw	startmonadres
 reg_pc	dw	startpcadres
 cursoradres	dw	startcursorad
 disoptabpc	dw	startcursorad
-	ds	(disopaantlijn*2)-2	; bijhorend adres per lijn
-disbuffer	ds	disopaantlijn*lglnlngh	;LIJNEN EINDE=0
+	ds	(disopaantlijn*2)-2	; corresponding address per line
+disbuffer	ds	disopaantlijn*lglnlngh	;LINES END=0
 ;
-; Init zorgt voor algehele initialisatie gegevens+opbouwen van de
-; kaders op het scherm
-initdis	ld	hl,3*80	; eerst opbouw schermkaderdisam
+; Init takes care of overall initialization data+building the
+; frames on the screen
+initdis	ld	hl,3*80	; first construction screen frame disam
 	ld	bc,uplijn
-	call	PRINTTEKST	; bovenste lijn
+	call	PRINTTEKST	; top line
 	ld	a," "
 	ld	(leeglijnend2),a
 	ld	hl,4*80
@@ -2853,22 +2853,22 @@ initdis	ld	hl,3*80	; eerst opbouw schermkaderdisam
 	ld	b,disopaantlijn
 _initdis1	exx
 	ld	bc,leeglijndb-1
-	call	PRINTTEKST	; telkens een lege lijn met strepen
+	call	PRINTTEKST	; each time an empty line with stripes
 	add	hl,de
 	exx
 	djnz	_initdis1
 	exx
-	inc	bc	;=ld bc,downlijn
-	call	PRINTTEKST	; onderste lijn
+	inc	bc	;=ld bc,downline
+	call	PRINTTEKST	; bottom line
 	xor	a
 	ld	(leeglijnend2),a
 	ld	a,disopaantlijn
 	ld	de,disbuffer
-_initdis2	ld	bc,lglnlngh	; buffer vullen met lege lijnen
+_initdis2	ld	bc,lglnlngh	; fill buffer with empty lines
 	ld	hl,leeglijndb
 	ldir
 	dec	a
-	jp	nz,_initdis2	;snelle jump
+	jp	nz,_initdis2	;quick jump
 
 	ld	hl,disoptabpc
 	ld	e,(hl)
@@ -2876,7 +2876,7 @@ _initdis2	ld	bc,lglnlngh	; buffer vullen met lege lijnen
 	ld	d,(hl)
 	ld	(reg_pcvdis),de
 
-disameenscherm	ld	b,disopaantlijn	;zorgt voor de opbouw van een scherm
+disameenscherm	ld	b,disopaantlijn	;creates a screen
 	ld	hl,disbuffer
 	ld	(waarbuffer),hl
 	ld	hl,disoptabpc
@@ -2912,7 +2912,7 @@ _disam1scherm3	ld	a,(aanduidtrace)
 	call	respcbalk
 	call	ispconscr
 ;
-; de routine zet alle lijnen op het scherm
+; the routine puts all the lines on the screen
 distoscr	ld	hl,80*4+1
 	ld	bc,disbuffer
 	exx
@@ -2937,8 +2937,8 @@ ispconscr	xor	a
 ispconscr1	ld	a,(hl)
 	inc	hl
 	cp	e
-	jr	z,ispconscr3	;jr die meestal niet w uitgevoerd: 7cks
-	inc	hl	;(is het snelste)
+	jr	z,ispconscr3	;jr not usually performed w: 7cks
+	inc	hl	;(is the fastest)
 	djnz	ispconscr1
 	ret
 ispconscr3	ld	a,(hl)
@@ -3033,7 +3033,7 @@ eenlijnup	ld	hl,(disoptabpc)
 	add	hl,de
 	ld	(reg_pcvdis),hl
 eenlijnup1	ld	(eenlijnuptmp),hl
-	call	eenlijnup0	; hl=hl+ lenghtecode op (hl)
+	call	eenlijnup0	; hl=hl+ lengthcode on (hl)
 	ld	de,(disoptabpc)
 	call	hlgelijkde
 	jr	c,eenlijnup1
@@ -3094,7 +3094,7 @@ routcursdown2	add	hl,de
 	call	distoscr
 	jp	updcursoradr
 
-; ZORGT DAT SCHERM EEN INSTRUCTIE VERDER GAAT
+; ALLOW SCREEN TO GO AHEAD ONE INSTRUCTION
 eenlijndown	ld	hl,disbuffer+lglnlngh
 	ld	de,disbuffer
 	ld	bc,(disopaantlijn-1)*lglnlngh
@@ -3169,7 +3169,7 @@ routandback7	add	hl,de
 	ld	(hl),a
 	jp	distoscr
 
-setpcbalk	add	a,3	; in: a bevat y-coordinaat voor balk
+setpcbalk	add	a,3	; in: a contains y-coordinate for bar
 	ld	l,a
 	push	hl
 	ld	h,disopwradres
@@ -3191,17 +3191,17 @@ respcbalk	add	a,3
 	ld	b,39
 	jp	WISBALK
 
-; zorgt voor opbouw van een lijn in het disassemblerkaders
-; benodigd is dat waarbuffer wijst naar begin v/d lijn
-; het aanpassen v/d adrestab moet buiten deze rout geb.
-disameenlijn	call	vulbuffer	; zorgt voor plaatsen 4 bytes
+; create a line in the disassembler frames
+; waarbuffer must point to the beginning of the line
+; adjusting the address tab must be done outside this route.
+disameenlijn	call	vulbuffer	;provides places 4 bytes
 	ld	de,(waarbuffer)
 	ld	hl,leeglijndb
-	ld	bc,lglnlngh-1	; aantal tek.per lege lijn
+	ld	bc,lglnlngh-1	; number of characters per empty line
 	ldir
-	ld	hl,(waarbuffer)	;sneller dan push/pop
+	ld	hl,(waarbuffer)	;faster than push/pop
 	push	hl
-	;add hl,disopwradres
+	;add hl,disopwraddress
 	inc	hl
 
 	ld	(waarbuffer),hl
@@ -3225,7 +3225,7 @@ _eenlijn1	pop	hl
 	ld	de,disopwrhex
 	add	hl,de
 	ld	(waarbuffer),hl
-	ld	hl,codebuffer	;de vierbytesbuffer
+	ld	hl,codebuffer	;the four-byte buffer
 	ld	a,(lenghtcode)
 	ld	b,a
 _eenlijn2	ld	a,(hl)
@@ -3244,7 +3244,7 @@ vulbuffer1	ld	bc,4
 	ldi
 	ldi
 	ret
-; dit is de echte routine
+; this is the real routine
 disassem	LD	HL,codebuffer
 	LD	(waarbufcode),HL
 	LD	HL,(waarbuffer)
@@ -3321,8 +3321,8 @@ notexist	LD	DE,(orgwaarbuf)
 	LD	HL,txtdb
 	LD	BC,18
 	LDIR
-	; code nodig voor txttobuffer
-	xor	a	; resetten byte of 16bits geplaatstis
+	; code needed for txttobuffer
+	xor	a	; reset byte or 16bit is inserted
 	ld	(hlopslag),a
 
 	LD	HL,(orgwaarbuf)
@@ -3394,7 +3394,7 @@ disassemIY	CALL	alixiy
 	LD	A,6
 	JR	disassemIX1
 
-; vanaf hl tekst naar buffer
+; from hl text to buffer
 codtxttobuf	LD	A,(HL)
 	AND	127
 	CP	32
@@ -3419,7 +3419,7 @@ all_ok_met_IXIY	LD	A,(hlixiy)
 	RET	NZ
 	JP	notexist
 
-; binnen a=stuurcode
+; input a=control code
 stuurcode	LD	HL,stuurcodtab-2
 stuurcode1	ADD	A,A
 	LD	E,A
@@ -3432,10 +3432,10 @@ stuurcode1	ADD	A,A
 	JP	leescodebyte
 
 
-stuurcodtab	DW	rs1bit02ixpv	;STUURCODE 1
-	DW	rsbit35	;STUURCODE 2
-	DW	rp1bit45af	;STUURCODE 3
-	DW	rp1bit45	;STUURCODE 4
+stuurcodtab	DW	rs1bit02ixpv	;CONTROL CODE 1
+	DW	rsbit35	;CONTROL CODE 2
+	DW	rp1bit45af	;CONTROL CODE 3
+	DW	rp1bit45	;CONTROL CODE 4
 	DW	addbit35	;
 	DW	ntobuffer	;6
 	DW	jradres
@@ -3454,8 +3454,8 @@ stuurcodtab	DW	rs1bit02ixpv	;STUURCODE 1
 	DW	idirdr	;20
 	DW	rstrout
 
-; zet single register naam bepaalt door bit 3-5 in A naar buffer
-; OOK OPLETTEN VOOR IX
+; set single register name determined by bit 3-5 in A to buffer
+; ALSO BEWARE FOR IX
 rsbit35	LD	E,A
 	AND	%00111000
 	CP	%00110000
@@ -3465,8 +3465,8 @@ rsbit35	LD	E,A
 	RRA
 	JR	rsbit02v
 
-; zet single register naam bepaalt door bit 0-2 in A naar buffer
-; EN H,L OMZETTEN IN IXH,IYL ENZ.
+;set single register name determined by bit 0-2 in A to buffer
+;AND CONVERT H,L TO IXH,IYL ETC.
 rsbit02	SLA	A
 rsbit02v	AND	%00001110
 	LD	D,0
@@ -3488,7 +3488,7 @@ rsbit02ixh	PUSH	HL
 	POP	HL
 	JP	regtobuffer
 
-; zet register bit 0-2 in A naar buffer met (HL) -> (IX/Y+d)
+; set register bit 0-2 in A to buffer with (HL) -> (IX/Y+d)
 rs1bit02ixpv	LD	E,A
 	AND	%00000111
 	CP	%00000110
@@ -3531,7 +3531,7 @@ J678C:	LD	C,A
 rsbit35ixpv2	LD	A,")"
 	JP	ascitobuffer
 
-; zet register bit 3-5 in A naar buffer met (HL) -> (IX/Y+d)
+; set register bit 3-5 in A to buffer with (HL) -> (IX/Y+d)
 rs1bit35ixpv	LD	E,A
 	AND	%00111000
 	CP	%00110000
@@ -3549,7 +3549,7 @@ rp1bit45af	LD	E,A
 	JR	NZ,rp1bit45
 	LD	HL,rp1txtaf
 	JR	regtobuffer
-; zet registerpaar geval1 naam bepaalt door bit 4-5 in A naar buffer
+; set register pair case1 name determined by bit 4-5 in A to buffer
 rp1bit45	RRA
 	RRA
 	RRA
@@ -3689,7 +3689,7 @@ bit35nr	RRA
 	CALL	atobuasci
 	JP	ascitobuffer
 
-codeonbestaand	POP	HL	; nietzekervan
+codeonbestaand	POP	HL	; not sure of
 	JP	notexist
 
 bcdeofadres	LD	E,A
@@ -4264,7 +4264,7 @@ routstep1	ld	hl,codebuffer
 	ld	(usedix),a
 	inc	a
 	ld	(lenghtcode),a
-	call	disassem1	;dient enkel voor aanpassen lenghtcode
+	call	disassem1	; only serves to adjust lenght code
 
 	ld	a,(codebuffer)
 	cp	#ED
@@ -4274,11 +4274,11 @@ routstep1	ld	hl,codebuffer
 	cp	#FD
 	jp	z,tracefdrout
 
-	cp	#fb	; kontrole op ei
+	cp	#fb	; check for ei
 	jr	nz,_tracedi
 	ld	a,1
 	jr	_tracedi1
-_tracedi	cp	#f3	; kontrole op di
+_tracedi	cp	#f3	; check for di
 	jr	nz,_tracehalt
 	xor	a
 _tracedi1	ld	(eiofdi),a
@@ -4326,7 +4326,7 @@ _tracenog	cp	#DB
 	cp	#C2
 	ld	a,c
 	jp	z,tracejpcc
-	cp	#E9	; EN HIER OP JP (HL)
+	cp	#E9	; AND HERE ON JP (HL)
 	jp	z,tracejphl
 	and	%11001111
 	cp	#C5
@@ -4338,9 +4338,9 @@ steprst	and	%11000111
 	ld	a,c
 	jp	z,specialtrace
 
-; Hier afbuigen subslotregisters
-; enkel afgebogen zijn ld (hl),r;ld r,(hl);
-;       ld (hl),n;ld a,(#ffff);ld (#ffff),a
+; Here deflect subslot registers
+; only deflected are ld (hl),r;ld r,(hl);
+;      ld (hl),n;ld a,(#ffff);ld (#ffff),a
 tracesubslot	cp	#3A
 	jr	z,tracesubslot1
 	cp	#32
@@ -4387,9 +4387,9 @@ tracesubslot5	call	hlwelffff	;LD (HL),r
 	call	get8bit0
 	ld	b,1
 
-ldffffw	push	af	; input a bevat waarde
+ldffffw	push	af	; input a contains value
 	call	bepaalsubslreg
-	jr	nc,writeffffram	;gewoon ram (not expanded)
+	jr	nc,writeffffram	; regular ram (not expanded)
 	pop	af
 	ld	(hl),a
 	rlca
@@ -4399,7 +4399,7 @@ ldffffw	push	af	; input a bevat waarde
 	ld	b,4
 _ldffffw	ld	a,(hl)
 	and	#3
-	cp	c	;C geladen door bepaalsubslreg :)
+	cp	c	; C loaded by determinesubslreg :)
 	jr	nz,_ldffffw2
 	ld	a,e
 	and	#0c
@@ -4415,25 +4415,25 @@ _ldffffw2	rrc	e
 	djnz	_ldffffw
 	jp	_outa8g
 
-writeffffram	;voorlopig nog****************************************
-	;eventueel werken via traceexecute!
+writeffffram	;for the time being********************************************
+	;possibly work via traceexecute!
 	pop	af
-	ld	(hl),a	;zou naar echt ram (#ffff) moeten
+	ld	(hl),a	;should go to real ram (#ffff)
 	jp	verzetpcblk
 
-ldwffff	call	bepaalsubslreg	; input de=pointer naar register
-	jr	nc,leesffffram	;gewoon ram op ffff (not expanded)
+ldwffff	call	bepaalsubslreg	; input de=pointer to register
+	jr	nc,leesffffram	;just ram on ffff (not expanded)
 	ld	a,(hl)
 	cpl
 	ld	(de),a
 	jp	verzetpcblk
-leesffffram	;voorlopig nog*******************************************
-	;werken via traceexecute!
-	ld	a,(hl)	;zou uit ram (#ffff) moeten komen
+leesffffram	;for the time being********************************************
+	;work via traceexecute!
+	ld	a,(hl)	;should come from ram (#ffff)
 	ld	(de),a
 	jp	verzetpcblk
 
-bepaalsubslreg	ld	a,b	; b bevat lengtecode
+bepaalsubslreg	ld	a,b	; b contains length code
 	ld	(lenghtcode),a
 	call	GETPAGES
 	ld	bc,6
@@ -4448,14 +4448,14 @@ bepaalsubslreg	ld	a,b	; b bevat lengtecode
 	ld	a,(welkismetsub)
 _bepaalsubsl	rrca
 	djnz	_bepaalsubsl
-	ret		;al dan niet carry
+	ret		;whether or not to carry
 
-hlwelffff	ld	hl,(reg_hl)	; routine mag enkel
-	ld	a,h	; terugkeren indien hl=#ffff
-	and	l	; zoniet springt routine
-	inc	a	; naar traceexecute
-	ld	a,c	; met zorg a=instructie-byte
-	ret	z	; na stackherstelling
+hlwelffff	ld	hl,(reg_hl)	; routine may only
+	ld	a,h	; return if hl=#ffff
+	and	l	; otherwise routine jumps
+	inc	a	; to traceexecute
+	ld	a,c	; with care a=instruction byte
+	ret	z	; after stack recovery
 	pop	hl
 	jp	traceexecute
 
@@ -4564,16 +4564,16 @@ _outd2	ld	(reg_hl),hl
 	ret
 
 traceinrca8	call	_ina8
-traceinrcfl	or	a	;zeer goede benadering flags!!
-	push	af	;H-flag schijnt bij IN steeds op 0
-	pop	hl	;te komen
-	ld	a,(reg_af)	;andere flaggen staan goed
-	and	1	;mix oude carryflag erover
+traceinrcfl	or	a	;very good approximation flags!!
+	push	af	;H-flag always shines at 0 at IN
+	pop	hl	;to come
+	ld	a,(reg_af)	;other flags are good
+	and	1	;mix old carry flag over it
 	or	l
 	ld	l,a
 	push	hl
 	pop	af
-	pop	bc	;b refreshen
+	pop	bc	;b refresh
 	push	bc
 	jr	_continrc
 traceinrcfc	call	_inmapper
@@ -4587,17 +4587,17 @@ traceinrc	push	bc
 	ld	c,a
 	ld	hl,(reg_af)
 	push	hl
-	pop	af	; trukje behouden c-flag
+	pop	af	; keep trick c-flag
 	in	a,(c)
 _continrc	push	af
-	call	get8bit	;in b uit a,de
+	call	get8bit	;in b from a,de
 	pop	hl
 	pop	bc
 	ld	a,l
 	ld	(reg_af),a
 	ld	a,b
-	and	%00111000	;check op IN F,(C)
-	CP	%00110000	;dit is wel degelijk nodig!
+	and	%00111000	;check for IN F,(C)
+	CP	%00110000	;this is indeed necessary!
 	JP	Z,verzetpcblk
 	ld	a,h
 	ld	(de),a
@@ -4608,10 +4608,10 @@ traceoutrc	call	get8bit
 	ld	a,(reg_bc)
 	jp	_outrout
 
-;IN  :   B BEVAT %??XXX??? MET XXX IS REGISTERNUMMER
-;UIT :   DE= POINT NAAR ADRES VAN REGISTER
-;        A = INHOUD VAN DIT REGISTER
-;WIJZIGT HL
+;IN  :   B CONTAINS %??XXX??? WITH XXX IS REGISTER NUMBER
+;OUT :   DE= POINT TO ADDRESS OF REGISTER
+;        A = CONTENTS OF THIS REGISTER
+;CHANGES HL
 get8bit	ld	a,b
 	rra
 	rra
@@ -4681,8 +4681,8 @@ traceoutna	ld	a,(reg_af+1)
 	ld	a,(codebuffer+1)
 	JP	_outrout
 
-; in: a bevat poortnr
-; out: a bevat poortwaarde
+; in: a contains port number
+; out: a contains port value
 _inrout	cp	#a8
 	jr	z,_ina8
 	cp	#FC
@@ -4709,11 +4709,11 @@ _inmapper	add	a,4
 	call	GETPAGES
 	inc	hl
 	add	hl,de
-	in	a,(#ff)	;bijmixen hoogste bits
+	in	a,(#ff)	;mix in highest bits
 	or	(hl)
 	ret
 
-; in b bevat waarde , a bevat poort
+; in b contains value , a contains port
 _outrout	cp	#A8
 	jp	z,_outa8
 	cp	#FC
@@ -4723,9 +4723,9 @@ _outrout	cp	#A8
 	out	(c),e
 	jp	verzetpcblk
 
-; testen of in lijst met verbodenouts
-; carry indien verboden
-; in a bevat te testen poort (gaat naar c), b de waarde (gaat naar e)
+; test for banned out list
+; carry if prohibited
+; in a contains port to test (goes to c), b the value (goes to e)
 verbodouttest	ld	c,a
 	ld	e,b
 	ld	hl,verbodenouts
@@ -4756,13 +4756,13 @@ _outa81	push	bc
 	rla
 	rla
 	and	3
-	ld	b,a	;a bevat nog steeds prim.slotnr.
+	ld	b,a	;a still contains prim.slot num
 	inc	b
 _outa82	rr	e
 	djnz	_outa82
 	jr	nc,_outa8f
-	pop	bc	;bugfix : reload B !!
-	push	bc	;bugfix
+	pop	bc	;bug fix : reload B !!
+	push	bc	;bug fix
 	push	de
 	push	hl
 	ld	d,0
@@ -4791,8 +4791,8 @@ _outa8g	call	verzetpcblk
 	ld	(reg_pcvdis),hl
 	jp	disameenscherm
 
-welkismetsub	db	0	; BIT X VOOR SLOT X
-subslotregs	db	0,0,0,0	;ingevuld bij eerste start debugger
+welkismetsub	db	0	; BIT X FOR SLOT X
+subslotregs	db	0,0,0,0	;filled in at first start debugger
 
 _outmapper	add	a,4
 	add	a,a
@@ -4805,7 +4805,7 @@ _outmapper	add	a,4
 	jp	_outa8g
 
 maxvbouts	equ	17
-verbodenouts	db	7	; eerste byte is aantal gedefinieerde poorten
+verbodenouts	db	7	; first byte is number of ports defined
 	db	#98,#99
 	db	#A9,#AA,#AB
 	db	#E4,#E5
@@ -4816,7 +4816,7 @@ tracepush	ld	a,c
 	call	_push
 	jp	verzetpcblk
 
-; in :de gegevens
+; in :the data
 _push	ld	hl,(bufferhoofdpr)
 	ld	(hl),e
 	inc	hl
@@ -4825,7 +4825,7 @@ _push	ld	hl,(bufferhoofdpr)
 	dec	hl
 	dec	hl
 	ld	(reg_sp),hl
-	ex	de,hl	;doeladres in DE
+	ex	de,hl	;target address in DE
 	ld	bc,2
 	jp	PUTTORAM
 
@@ -4841,7 +4841,7 @@ tracepop	ld	a,c
 	ld	(hl),d
 	jp	verzetpcblk
 
-; out: DE=gepopte waarde
+; out: DE=popped value
 _pop	ld	hl,(reg_sp)
 	ld	bc,2
 	call	GETFROMRAM
@@ -4855,14 +4855,14 @@ _pop	ld	hl,(reg_sp)
 	ld	d,(hl)
 	ret
 
-;*********************************************wordt niet gebruikt !
+;*********************************************is not being used !
 ;traceexsphl      ld      hl,(reg_hl)
 ;                 call    _exsphl
 ;                 ld      (reg_hl),hl
 ;                 jp      verzetpcblk
 ;
-;; in hl bevat te wisselen gegevens
-;; uit hl bevat wissel
+;; in hl contains data to be exchanged
+;; out hl contains change
 ;_exsphl          push    hl
 ;                 call    _pop
 ;                 pop     hl
@@ -4919,11 +4919,11 @@ traceret	call	_pop
 	ld	(hl),d
 	jp	regpcen0
 ;
-; Routine die moet controleren of aan een
-; conditie voldaan is. Is dit zo dan zal
-; Z-flag =0 anders nz
-; in: a bevat bit 3,4,5
-; (SIMPEL MET AND #38)
+; Routine that should check if a
+; condition is met. If so then will
+; Z-flag =0 else nz
+; in: a contains bit 3,4,5
+; (SIMPLE WITH AND #38)
 ;
 conditvoldaan	ld	hl,condittab
 	rra
@@ -4996,7 +4996,7 @@ pijlonscrback	ld	hl,(verzetpc2)
 	ld	(aanduiddisam),a
 	jp	disameenscherm
 
-; DE bevat adres achter pijl, deze moet op scherm staan
+; DE contains address behind arrow, it must be on screen
 adresnapijl	ld	a,(aanduiddisam)
 	call	getadrnapijl
 	ld	a,(aanduiddisam)
@@ -5007,12 +5007,12 @@ adresnapijl	ld	a,(aanduiddisam)
 	ret
 
 verzetpc1	db	0
-verzetpc2	dw	0	; adresbeginscherm
-verzetpc3	dw	0	; adres achter pijl
+verzetpc2	dw	0	; start address of screen
+verzetpc3	dw	0	; address behind arrow
 
 reg_ir	dw	0	;lowbyte=r highbyte=i
 
-reg_sp	dw	0	;wordt ingevuld bij init
+reg_sp	dw	0	;is filled in at init
 reg_iy	dw	0
 reg_ix	dw	0
 reg_bcac	dw	#4947
@@ -5025,9 +5025,9 @@ reg_hl	dw	#554E
 reg_af	dw	#4D53
 eiofdi	db	0
 
-; routine die zorgt voor het uitvoeren van niet adresgebonden
-; instructies met uitzondering van bepaalde zoals halt,ei,di
-; zorgt voor juist zetten af;bc;de;hl+spiegelregister
+; routine that performs non-address-bound
+; instructions with the exception of certain ones such as halt,ei,di
+; ensures correct setting of af;bc;de;hl+alternate registers
 ; +ix,iy+sp
 uitvoeradres	DB	0,0,0,0
 executesimpl	ld	hl,0
@@ -5050,9 +5050,9 @@ executesimpl	ld	hl,0
 	ld	bc,eiofdi-reg_sp+1
 	ldir
 	ret
-; in a gegevens herkenning in bit 4-5
-; uit : de bevat gegevens reg_??, hl bevat plaats reg_??
-; wijzight hl,de,c,af
+; in a data recognition in bit 4-5
+; out : de contains data reg_??, hl contains place reg_??
+; change hl,de,c,af
 self	rra
 	rra
 	rra
@@ -5067,7 +5067,7 @@ self	rra
 	ex	de,hl
 	ld	e,(hl)
 	inc	hl
-	ld	d,(hl)	; de bevat adres in regpaar
+	ld	d,(hl)	; de contains address in regpair
 	dec	hl
 	ret
 reg16point	dw	reg_bc
@@ -5308,7 +5308,7 @@ maininstall	ld	(Coloradres),de
 	xor	a
 	call	FILLVRAM
 	ld	hl,3*10+#1800
-	ld	bc,24*10	;ZO LATEN !  
+	ld	bc,24*10	;LEAVE IT !
 	xor	a
 	call	FILLVRAM
 	ld	hl,Main_y*80+24
@@ -5424,7 +5424,7 @@ _mainsp7:
 _mainsp7_1:
 	ld	d,0
 	ld	iy,(Coloradres)
-	add	iy,de	;IY = adres kleuren (#RB, #0G)
+	add	iy,de	;IY = address colors (#RB, #0G)
 	ld	a,b
 	add	a,Main_y+9
 	ld	l,a
@@ -5495,7 +5495,7 @@ _mainsp11:
 	ld	de,kbuf+211
 	ld	bc,25
 	ldir
-	call	saveinstall	;debuggerpars reeds in kbuf zetten
+	call	saveinstall	;already put debuggerpars in kbuf
 	call	SAVEINSTALL
 	jp	_main_hoofd
 mainberbalk:
@@ -5534,20 +5534,20 @@ printmain:
 _printmain1:
 	ld	ix,(Coloradres)
 	ld	hl,(Main_y+9)*80+42
-	call	printcolor	;color 1 = kleurnr 0
+	call	printcolor	;color 1 = color num 0
 	ld	de,15*2
 	add	ix,de
 	ld	hl,(Main_y+10)*80+42
-	call	printcolor	;color 2 = kleurnr 15
+	call	printcolor	;color 2 = color num 15
 	ld	ix,(Coloradres)
 	ld	de,3*2
 	add	ix,de
 	ld	hl,(Main_y+11)*80+42
-	call	printcolor	;color 3 = kleurnr 3
+	call	printcolor	;color 3 = color num 3
 	dec	ix
 	dec	ix
 	ld	hl,(Main_y+12)*80+42
-	jp	printcolor	;color 4 = kleurnr 2
+	jp	printcolor	;color 4 = color num 2
 printmainid:
 	ld	b,d
 	ld	c,e

--- a/Compass129Sources/DATfile/EDIT126.ASC
+++ b/Compass129Sources/DATfile/EDIT126.ASC
@@ -1,28 +1,28 @@
 ;Compass v1.2.06 editor
 ;JDS 24/10/98
 
-;compileren met 'assemble to disk' (ivm doubleusepage)
+;compile with 'assemble to disk' (due to doubleusepage)
 
-;stat_memory=2of3 toegestaan (=memman+dos1/memman+dos2)
-;TPAnrs aangepast
+;stat_memory=2or3 allowed (=memman+dos1/memman+dos2)
+;TPA nums adjusted
 
-;Opbouw textbuffers:
-;Zin, laatste teken heeft bit 7 hoog (#80=lege zin)
+;Structure of text buffers:
+;Sentence, last character has bit 7 high (#80=empty sentence)
 
-;Opbouw adressen:
-;Blok (1-..), adres low, adres high  (#ff = einde tekst)
+;Building addresses:
+;Block (1-..), address low, address high (#ff = end of text)
 
-;Header asmfile: #fc,hele textbl.,restlengte,hele databl.,restlengte,eindregel
-;       Lengtes:  1 ,     1      ,    2     ,  1       ,       2    ,  2
+;Header asmfile: #fc,whole textbl.,residuallength,whole databl.,residuallength,endline
+;       Lengtes:  1 ,     1      ,       2     ,       1       ,       2    ,    2
 
-;Info: ld a,""" en ld a,"" zijn niet toegestaan !
+;Info: ld a,""" and ld a,"" are not allowed !
 
 	.label	13
 
-Doubleadres:	equ	#3f40	;adres double-use data
+Doubleadres:	equ	#3f40	;address double-use data
 bdos:	equ	#f37d
-kbuf:	equ	#f41f	;buffer van 318 bytes
-startbuf	equ	1	;sourcebuffer waarmee gestart wordt
+kbuf:	equ	#f41f	;318 byte buffer
+startbuf	equ	1	;source buffer to start with
 tab_tpa	equ	#fa01
 
 setvramwrite:	equ	#80
@@ -107,7 +107,7 @@ Ctrl_l:	equ	1+"L"-"A"
 Ctrl_n:	equ	1+"N"-"A"
 Ctrl_p:	equ	1+"P"-"A"
 Ctrl_q:	equ	1+"Q"-"A"
-;Ctrl_r:       ;Zie ctrl
+;Ctrl_r: ;See ctrl
 Ctrl_s:	equ	1+"S"-"A"
 Ctrl_t:	equ	1+"T"-"A"
 Ctrl_v:	equ	1+"V"-"A"
@@ -116,12 +116,12 @@ Ctrl_z:	equ	1+"Z"-"A"
 
 Commline:	equ	12
 
-;entries in de assembly module
+;entries in the assembly module
 assembledisk:	equ	#4000
 assembleren:	equ	#4003
 ;labbufvol:    equ     #4006 ;*********************************
 prterrlines:	equ	#4009
-;testlabel:    equ     #400c  ;***********    ;voor calculator/berekengetal
+;test label: equ #400c  ;***********    ;for calculator/calculation number
 geeflabdata:	equ	#400f
 relocatable:	equ	#4012
 asstsr	equ	#4015
@@ -149,14 +149,14 @@ startassemb	LD	(entryA),A
 	ld	hl,Doubleusepg1
 	ld	de,Doubleadres
 	ld	bc,Doubleuseend-Doubleuse
-	ldir		;naar page 0 kopieeren
+	ldir		;copy to page 0
 	CALL	transbufp02p1
 	pop	hl
 	ld	(Bufferpage0),ix
 	ld	(Sp_back),sp
 	ld	de,Idhex
 	ld	bc,6
-	ldir		;kopieer idhex en idbin
+	ldir		;copy idhex and idbin
 	ld	a,(Keer)
 	or	a
 	jr	nz,_niet1ekeer1
@@ -179,7 +179,7 @@ _niet1ekeer1:
 	or	a
 	jr	nz,_niet1ekeer
 	call	prtcodename
-	call	ini_variabel	;toch niet meer nodig??? (zit al in
+	call	ini_variabel	;no need anymore??? (already in
 _niet1ekeer:	call	tekenscherm	;delsource1)************************
 	ld	a,1
 	ld	(Keer),a
@@ -189,12 +189,12 @@ _niet1ekeer:	call	tekenscherm	;delsource1)************************
 	CALL	NZ,doinclude
 	JP	editor
 Sp_back:	defw	0
-Keer:	defb	0	;0=1e keer
+Keer:	defb	0	;0=1st time
 entryA	db	0
 
 transbufp02p1	exx
 	LD	HL,(entryDE)
-	ld	de,Textbuffer1	;in page 1
+	ld	de,Textbuffer1	;on page 1
 	ld	bc,(33+13)*4
 	ldir
 	ld	de,Aantallabelb	;in page 0
@@ -215,9 +215,9 @@ J40AF:	LD	BC,4
 	DEC	A
 	JR	NZ,J40AF
 	RET
-;----- Regel van debugger naar sourcebuffer
-;----- IN:  HL = adres regel
-;----- UIT: [C] = error (een buffer vol)
+;----- Line from debugger to sourcebuffer
+;----- IN:  HL = address line
+;----- OUT: [C] = error (one buffer full)
 linedebugger:
 	ld	(Sp_debugger),sp
 	PUSH	AF
@@ -257,7 +257,7 @@ debuggerfout:
 	ret
 Sp_debugger:	defw	0
 
-;----- Verander funktietoetsen: F1=255, F2=254, F3=253, F4=252, F5=251
+;----- Change function keys: F1=255, F2=254, F3=253, F4=252, F5=251
 changefkey:
 	ld	hl,#f87f
 	ld	de,16-1
@@ -279,7 +279,7 @@ _changefkey1:
 	ret
 Oldfkey:	ds	10
 
-;----- Herstel funktietoetsen
+;----- Restore function keys
 oldfkey:
 	ld	hl,#f87f
 	ld	de,16-1
@@ -297,7 +297,7 @@ _oldfkey1:
 	djnz	_oldfkey1
 	ret
 
-;--------------- Menu's
+;--------------- Menus
 menu2tomenu:
 	push	bc
 	call	wisoudmenu
@@ -318,7 +318,7 @@ startmenu:
 Menus:	defw	menu1,menu2,menu3,menu4,menu5
 Lastmenu:	defb	1
 
-;----- Ga naar diskdrive
+;----- Go to disk drive
 
 gotodisk:
 	ld	a,(Textbuffer)
@@ -397,14 +397,14 @@ Menu1opties:	defw	!mon,!deb,!disk,!mem,!calc,!slot,!shell,!quit
 	ld	b,0
 	ld	ix,Pointerdisk
 	call	gotodisk
-	call	c,inishowlab1	;Als geformatteerd => labels weg
+	call	c,inishowlab1	;As formatted => labels gone
 	jp	editor_cont
 
 Diskregel:	defw	0
 Pointerdisk:
-	defw	loadasmfile,saveasmfile	;assemblerfile
+	defw	loadasmfile,saveasmfile	;assembler file
 	defw	loadascfile,saveascfile	;asciifile
-	defw	loadblock,saveblock	;blockfile
+	defw	loadblock,saveblock	;block file
 
 ;##### Memory
 !mem:
@@ -416,9 +416,9 @@ Pointerdisk:
 	ld	bc,9
 	ldir
 	ld	a,(Textbuffer)
-	call	setbuffer	;4e8d MOET
+	call	setbuffer	;4e8d MUST
 _mem1:
-editscreen:	;ZO LATEN !
+editscreen:	;LEAVE IT !
 	ld	hl,25*80
 	ld	bc,2*80
 	xor	a
@@ -455,15 +455,15 @@ backtohoofd:
 	ld	hl,Doubleadres
 	ld	de,Doubleusepg1
 	ld	bc,Doubleuseend-Doubleuse
-	ldir		;van page 0 terug kopieeren
+	ldir		;copy back from page 0
 	pop	af
 	ld	sp,(Sp_back)
-	ret		;terug naar hoofdprogramma
+	ret		;back to main program
 
 Quit:	defb	"Quit: ",0
 
 Menu1:
-	defb	8,13,0	;hoogte,breedte tekst,plaats ondergrond
+	defb	8,13,0	;height, width text, place background
 	defb	"Monitor      "
 	defb	"Debugger     "
 	defb	"Disk       ^D"
@@ -749,7 +749,7 @@ _search1:
 	ld	hl,10*80+33
 	ld	bc,25
 	xor	a
-	call	fillvram	;ZO LATEN !
+	call	fillvram	;LEAVE IT !
 	ld	bc,Searchtext
 	ld	hl,10*80+33
 	call	printtekst
@@ -904,10 +904,10 @@ Upper:	defb	"Upper",0
 On:	defb	"on ",0
 Off:	defb	"off",0
 
-;#### IN DEZE VOLGORDE LATEN STAAN !!!! ####
+;#### LEAVE IN THIS ORDER!!!! ####
 Searchlengte:	defb	0
 Searchreplac:	defb	0	;0=search, 1=replace
-Vooruitachte:	defb	0	;0=vooruit, 1=achteruit
+Vooruitachte:	defb	0	;0=forward, 1=backwards
 Searchupper:	defb	0	;0=upper off, 1=upper on
 
 Searchtext:	defs	26
@@ -972,15 +972,15 @@ Jumptoline:	defb	"Line:",0
 Deletesource:	defb	"Delete source: ",0
 
 delsource1:
-	call	wistext	;wis textbuffer
+	call	wistext	;clear text buffer
 	ld	a,(Aantaldatabl)
 	ld	b,a
 	ld	ix,Databuffers
-	call	_wisbuffer1	;wis databuffer
+	call	_wisbuffer1	;clear data buffer
 	ld	a,1
 	call	zetdatablok
 	ld	a,#ff
-	ld	(#8000),a	;einde databuffer
+	ld	(#8000),a	;end of data buffer
 	jp	ini_variabel
 
 Menu3:
@@ -1328,11 +1328,11 @@ _printreg1:
 	ld	b,a
 	bit	6,b
 	ld	hl,16*80+35
-	ld	a,0	;ZO LATEN !
+	ld	a,0	;LEAVE IT !
 	call	nz,writevram
 	bit	0,b
 	ld	hl,16*80+40
-	ld	a,0	;ZO LATEN !
+	ld	a,0	;LEAVE IT !
 	call	nz,writevram
 	bit	1,b
 	ld	hl,16*80+46
@@ -1479,12 +1479,12 @@ Regtxt:
 	ld	de,kbuf
 	push	de
 	ld	bc,31
-	ldir		;GETAL MOET IN PAGE 0 STAAN !!!
+	ldir		;AMOUNT MUST BE IN PAGE 0 !!!
 	pop	hl
 	call	berekengetal
 	jr	c,!go_error
 	ld	h,d
-	ld	l,e	;startadres
+	ld	l,e	;start address
 	ld	(Startadres),hl
 	call	oldfkey
 	call	oldscreen
@@ -1494,11 +1494,11 @@ Regtxt:
 	call	changefkey
 	call	tekenscherm
 	ld	hl,(#f3f8)
-	ld	(#f3fa),hl	;toets getadres = putadres
+	ld	(#f3fa),hl	;key getadres = putaddress
 	jp	editor_cont
 Data:	defb	#cd	;call
 Startadres:	defw	0
-	defb	0	;4e byte
+	defb	0	;4th byte
 Gohok:	defw	Eh1,Eh2,Eh3,0
 Go:	defb	"Go "
 Gotxt:	defs	30+1
@@ -1583,7 +1583,7 @@ menuoptie:
 	ex	de,hl
 	jp	(hl)
 
-;----- Vraag: are you sure ?   UIT: [C]=nee
+;----- Question: are you sure? OUT: [C]=no
 
 areyousure:
 	ld	a,1
@@ -1604,25 +1604,25 @@ areyousure:
 	ret
 Areyousure:	defb	"Are you sure ? (y/n)",0
 
-gobios:	;***************gebruikt???***********************************
+gobios:	;***************used???***********************************
 	push	iy
 	ld	iy,(#fcc0)
 	call	#1c
 	pop	iy
 	ret
 
-;########### Schakelt buffer in A en test of deze in orde is
+;########### Enables buffer A and tests if it is OK
 ;----- IN:  A=buffer
-;----- UIT: [C]=error, (Oldbuffer)=oude buffer
+;----- OUT: [C]=error, (Oldbuffer)=old buffer
 
 setnewbuffer:
 	call	setbuffer
 	ld	a,(Aantaltextbl)
 	or	a
-	jr	z,_setnewbuf1	;geen textblokken
+	jr	z,_setnewbuf1	;no text blocks
 	ld	a,(Aantaldatabl)
 	or	a
-	jr	z,_setnewbuf1	;geen datablokken
+	jr	z,_setnewbuf1	;no data blocks
 	xor	a
 	ret
 _setnewbuf1:
@@ -1632,7 +1632,7 @@ _setnewbuf1:
 	ret
 
 
-;##################### schakel huidige text+data buffer
+;##################### toggle current text+data buffer
 ;----- IN: A=buffer
 
 setbuffer:
@@ -1652,8 +1652,8 @@ setbuffer1:
 	ret	z
 	cp	16+1
 	jr	nc,_data_error
-	call	getdatbuffer	;ev. eenvoudiger aangezien adres
-	call	getdatbuffer	;8001 of 8002 is *********************
+	call	getdatbuffer	;possibly simpler since address
+	call	getdatbuffer	;8001 or 8002 is *********************
 	and	%11000000
 	cp	%10000000
 	ret	z
@@ -1662,13 +1662,13 @@ _data_error:
 	jp	ini_variabel
 
 setbuffonly:
-	push	af	;beter****ex af,af'*******?
+	push	af	;better****ex af, af'*******?
 	ld	a,(Textbuffer)
 	ld	(Oldbuffer),a
 	call	putinst
 	pop	af
 setbuffonly1:
-	ld	(Textbuffer),a	;LATEN STAAN !!!
+	ld	(Textbuffer),a	;LEAVE !!!
 	ld	b,a
 	ld	hl,Textbuffer1-(Textbuffer2-Textbuffer1)
 	ld	de,Textbuffer2-Textbuffer1
@@ -1682,7 +1682,7 @@ _setbuffer1:	add	hl,de
 	ldir
 	jp	iniasm1
 
-;sla huidige positie/parameters op in buffer A
+;store current position/parameters in buffer A
 putinst:
 	call	positie_adre
 	ex	de,hl
@@ -1720,7 +1720,7 @@ iniasm1:
 	ld	(Huidigupper),a
 	ret
 
-;##################### Wis textbuffers
+;#################### Clear text buffers
 
 wistext:
 	ld	a,(Aantaltextbl)
@@ -1748,7 +1748,7 @@ wisbuffer:
 	ld	a,1
 	call	zetdatablok
 	ld	a,#ff
-	ld	(#8000),a	;einde databuffer
+	ld	(#8000),a	;end of data buffer
 	ld	a,(Doinclude)
 	or	a
 	ret	nz
@@ -1815,7 +1815,7 @@ ini_variabel:
 _noturbor:	ld	(Turbor),a
 	ret
 
-;############################ Teken scherm
+;########################### Draw screen
 
 tekenscherm:
 	ld	hl,Teksten
@@ -1847,13 +1847,13 @@ Teksten:
 
 
 
-;############################ Besturing in editor
+;########################### Controls in editor
 
-Bovenaantext:	equ	4	;y-positie bovenaan
-Onderaantext:	equ	25	;y-positie onderaan
-Aantalrgltxt:	equ	22	;aantal regels
+Bovenaantext:	equ	4	;y position on top
+Onderaantext:	equ	25	;y position at the bottom
+Aantalrgltxt:	equ	22	;number of lines
 
-bufferfout:	;cursor te hoog !
+bufferfout:	;cursor too high !
 	call	wisbuffer
 	jr	editor_cont
 
@@ -1869,7 +1869,7 @@ editorbestur:
 	ld	hl,(Editor_y)
 	ld	a,l
 	cp	Bovenaantext
-	jr	c,bufferfout	;!!!!! (cursor te hoog)
+	jr	c,bufferfout	;!!!!! (cursor too high)
 	LD	A,(afb_offset)
 D5098:	LD	B,A
 J5099:	LD	A,H
@@ -1877,14 +1877,14 @@ J5099:	LD	A,H
 	LD	H,A
 	ld	(Cursorpositi),hl
 	xor	a
-	ld	(Bronerrors),a	;fouten van editor
-	ld	(Doinclude),a	;VOOR DE VEILIGHEID
-	ld	(Cursoronoff),a	;cursor aan
+	ld	(Bronerrors),a	;editor errors
+	ld	(Doinclude),a	;FOR SAFETY
+	ld	(Cursoronoff),a	;cursor on
 	call	printinfoRnr
 
 	ld	bc,#0101
 	call	mouseoffset
-	call	#0134	;********************vroeger getkey****
+	call	#0134	;******************** used to be getkey****
 	cp	241
 	jr	c,_noctrl1234
 	cp	245
@@ -1920,7 +1920,7 @@ editor_norm:
 editor_ctrl:
 	ld	a,(Matrix+4)
 	rlca
-	jp	nc,printerrors1	;ctrl-r = ins, daarom hier
+	jp	nc,printerrors1	;ctrl-r = ins, therefore here
 	ld	a,(Matrix+6)
 	ld	d,1
 	rlca
@@ -2070,7 +2070,7 @@ Ctrladresret:
 	defw	!disk,!calc
 
 
-;----- Test of B=funktietoets, zo ja: C=menunr (1-5) en [NC]
+;----- Test whether B=function key, if so: C=menu no (1-5) and [NC]
 
 testfkey:
 	ld	a,b
@@ -2082,21 +2082,21 @@ testfkey:
 	xor	a
 	ret
 
-;----- Test of toets is ingedrukt+start programma  IN: B=toets+C  UIT: [C]=nee
-;----- Pop't call als juiste toets
+;----- Test whether key is pressed+start program IN: B=key+C OFF: [C]=no
+;----- Pop't call if correct key
 
 testkey:
 	ld	a,(ix)
 	inc	ix
 	or	a
 	scf
-	ret	z	;foute toets
+	ret	z	;wrong key
 	cp	b
 	jr	z,_testkey1
 	inc	iy
 	inc	iy
 	jr	testkey
-_testkey1:	pop	hl	;call weghalen !!!
+_testkey1:	pop	hl	;remove call !!!
 	ld	l,(iy)
 	ld	h,(iy+1)
 	push	hl
@@ -2104,11 +2104,11 @@ _testkey1:	pop	hl	;call weghalen !!!
 	or	a
 	call	nz,edit_ret1
 	pop	hl
-	jp	(hl)	;start adres
+	jp	(hl)	;start address
 
 
 
-;######################### Editorcommando's uitgewerkt
+;######################## Editor commands worked out
 
 ;----- Ctrl+g: Go to line
 
@@ -2262,7 +2262,7 @@ editor_ins:
 
 ;org 5381:
 
-;----- Klein naar groot, groot naar klein
+;----- Small to large, large to small
 
 edit_graph:
 	CALL	C53DC
@@ -2298,7 +2298,7 @@ _nograph:	call	J53F9
 	jp	nz,editor_left
 	jp	editor_right
 
-;----- letter ingetoetst
+;----- letter keyed in
 
 edit_letter:
 	call	edit_letter1
@@ -2362,7 +2362,7 @@ editor_tab:
 	ld	a,(Editor_x)
 	LD	B,A
 	dec	a
-	ld	c,a	;C = huidige positie 0-79
+	ld	c,a	;C = current position 0-79
 	ld	iy,Tabs
 _edit_tab2:	ld	a,(iy)
 	inc	iy
@@ -2375,7 +2375,7 @@ _edit_tab2:	ld	a,(iy)
 _edit_tab1:
 	ld	a,c
 	inc	a
-	sub	b	;lengte
+	sub	b	;length
 	jr	z,_edit_tab5
 	ld	b,a
 _edit_tab4:
@@ -2429,7 +2429,7 @@ edit_ctrlri2:	ld	a,b
 	and	%11011111
 	jr	nz,edit_ctrlri2
 edit_ctrlri5:
-	ld	c,b	;separator gevonden
+	ld	c,b	;separator found
 	dec	c
 edit_ctrlri3:	ld	a,b
 	cp	161
@@ -2551,7 +2551,7 @@ zetstartblok:
 	ld	b,a
 	ld	a,(Textbuffer)
 	cp	b
-	jr	z,_zetstartbl2	;zelfde buffer
+	jr	z,_zetstartbl2	;same buffer
 	ld	(Blokbuffer),a
 	ld	hl,(Laatsteregel)
 	dec	hl
@@ -2585,7 +2585,7 @@ _zeteindblk3:
 	ld	b,a
 	ld	a,(Textbuffer)
 	cp	b
-	jr	z,_zeteindblk2	;zelfde buffer
+	jr	z,_zeteindblk2	;same buffer
 	ld	(Blokbuffer),a
 	ld	hl,1
 	ld	(Blokstart),hl
@@ -2641,7 +2641,7 @@ _printloop:
 	ei
 	ld	hl,80*Commline+21+9
 	ld	de,(Printline)
-	ld	b,5	;met voorloopspaties
+	ld	b,5	;with leading spaces
 	call	printdecimaa
 	ei
 	ld	a,(Matrix+7)
@@ -2649,10 +2649,10 @@ _printloop:
 	jr	z,_printabort
 	ld	de,(Printline)
 	call	haalzinzin
-	jr	c,_printend	;einde tekst
+	jr	c,_printend	;end of text
 	ld	hl,Zin
 	ld	ix,#a5
-	ld	b,a	;lengte
+	ld	b,a	;length
 _printnexttk:	ld	a,(hl)
 	or	a
 	jr	nz,_printteken1
@@ -2682,7 +2682,7 @@ _printend:
 _printabort:
 	call	wiscommline
 _printabor1:
-	call	getkey	;toets wegwerken
+	call	getkey	;eliminate test
 	ld	a,(Oldbuffer)
 	call	setbuffonly
 	ld	hl,Commline*80+(80-18)/2
@@ -2705,7 +2705,7 @@ cursorinblok:
 Cursorinblok:	defb	"Destination in block !",0
 
 Printabort:	defb	"Printing aborted !",0
-Printline:	defw	0	;huidige regel bij printen
+Printline:	defw	0	;current line when printing
 Printing:	defb	"Printing       -          Esc = abort",0
 Prtnotready:	defb	"Printer not ready !",0
 Noblock:	defb	"No block selected !",0
@@ -2719,21 +2719,21 @@ testisblock:
 	ccf
 	ret
 
-;----- UIT: 0=voor cursor, 1=cursor in blok, 2=na cursor
+;----- OFF: 0=before cursor, 1=cursor in block, 2=after cursor
 waarisblock:
 	ld	a,(Textbuffer)
 	ld	b,a
 	ld	a,(Blokbuffer)
 	cp	b
 	ld	a,0
-	ret	nz	;andere buffer
+	ret	nz	;other buffer
 	ld	hl,(Blokeinde)
 	ld	de,(Regelnr)
 	call	rst20
 	ld	a,0
-	ret	c	;voor
+	ret	c	;in front of
 	ld	hl,(Blokstart)
-	inc	hl	;1e regel mag wel
+	inc	hl	;1st line is allowed
 	ld	de,(Regelnr)
 	call	rst20
 	ld	a,1
@@ -2742,12 +2742,12 @@ waarisblock:
 	inc	a
 	ret
 
-;----- HOME => Naar begin/einde buffer
+;----- HOME => To start/end buffer
 
 edit_home:
 	ld	a,(Matrix+8)
 	and	%10
-	jp	nz,editorbestur	;toch niet ingedrukt
+	jp	nz,editorbestur	;still not pressed
 
 	call	edit_ret1
 	ld	hl,(Regelnr)
@@ -2785,7 +2785,7 @@ _edit_home3
 	jp	editorbestur
 
 
-;----- RETURN => Zin naar textbuffer
+;----- RETURN => Sentence to textbuffer
 
 Edit_ret_sp:	defw	0
 
@@ -2810,13 +2810,13 @@ _editret3:
 	inc	(hl)
 	ld	a,(hl)
 	cp	160
-	jr	z,_editret2	;insert na huidige regel
+	jr	z,_editret2	;insert after current line
 	ld	a,(de)
 	inc	de
 	and	255-32
 	jr	z,_editret3
 
-	call	edit_ret2	;insert voor huidige regel
+	call	edit_ret2	;insert before current line
 	call	insline1
 	ld	hl,nietdown
 	ld	(jpinvul+1),hl
@@ -2824,7 +2824,7 @@ _editret3:
 	push	hl
 	jr	_editretcnt1
 
-_editret2:	;Insert na huidige regel
+_editret2:	;Insert after current line
 	call	edit_ret2
 	ld	hl,(Regelnr)
 	push	hl
@@ -2836,7 +2836,7 @@ _editretcnt1:
 	cp	15
 	jr	c,_editret4
 	call	downschuif
-	jr	c,_editret4	;kan niet
+	jr	c,_editret4	;can not
 	call	upnormal
 _editret4:
 	pop	hl
@@ -2865,21 +2865,21 @@ nietdown	ld	hl,editor_djon
 edit_ret1:
 	ld	a,(Veranderd)
 	or	a
-	ret	z	;geen verandering aan regel
+	ret	z	;no line change
 edit_ret2:	xor	a
 	ld	(Veranderd),a
 	inc	a
 	ld	(Printret),a
-	ld	hl,Labelbuffer+159	;achteraan beginnen
+	ld	hl,Labelbuffer+159	;start at the back
 	ld	b,160
 	ld	de,Zin+159
 _edit_ret2:	ld	a,(hl)
 	and	%11011111
-	jr	nz,_edit_ret1	;teken gevonden
+	jr	nz,_edit_ret1	;symbol found
 	dec	hl
 	dec	de
 	djnz	_edit_ret2
-	jr	_edit_ret3	;lege regel
+	jr	_edit_ret3	;empty line
 
 _edit_ret1:	push	de
 _edit_ret4:	ld	a,(hl)
@@ -2896,23 +2896,23 @@ _edit_ret3:	inc	de
 	ld	(de),a
 
 
-_return_cont:	;AANROEP VANUIT COPYBLOCK !!!
+_return_cont:	;CALLING FROM COPYBLOCK !!!
 	ld	(Edit_ret_sp),sp
 	xor	a
 	ld	(Reteinde),a
-	call	makeline	;A=lengte, zin op ZIN+128
+	call	makeline	;A=length, sentence on ZIN+128
 	ld	(Lengtezin),a
 
 	ld	de,(Regelnr)
-	call	geefadrrege1	;DE=adres datablok, C=blok
+	call	geefadrrege1	;DE=address data block, C=block
 	push	de
 	ld	a,c
 	push	af
 	ld	de,(Regelnr)
-	call	geefadrregel	;DE=adres textblok, A=blok
+	call	geefadrregel	;DE=address textblock, A=block
 	jr	nc,editret_wis0
 
-	ld	a,1	;laatste regel
+	ld	a,1	;last line
 	ld	(Reteinde),a
 	ld	hl,Aantaldatabl
 	pop	af
@@ -2928,10 +2928,10 @@ _return_cont:	;AANROEP VANUIT COPYBLOCK !!!
 	cp	#fd
 	jr	c,editret_end
 	ld	a,(Bronerrors)
-	cp	2	;komt men van uit linedebugger2editor?
+	cp	2	;does it come from linedebugger2editor?
 	call	nz,printscherm
 	ld	sp,(Edit_ret_sp)
-	jp	error2	;databuffer vol
+	jp	error2	;data buffer full
 editret_end:	ld	hl,(Laatsteregel)
 	inc	hl
 	ld	(Laatsteregel),hl
@@ -2950,11 +2950,11 @@ editret_wis1:	call	gettxtbuffer
 	pop	de
 editret_wis2:	xor	a
 	call	puttxtbuffer
-	djnz	editret_wis2	;wis oude regel
+	djnz	editret_wis2	;delete old line
 
 editret_fill:	ld	a,(Lengtezin)
 	ld	b,a
-	call	freespace	;[C]=vol
+	call	freespace	;[C]=full
 	jp	c,_bufvol
 	ld	b,a
 	pop	af
@@ -2970,7 +2970,7 @@ editret_fill:	ld	a,(Lengtezin)
 	or	a
 	jr	z,edit_no_end
 	ld	a,#ff
-	ld	(de),a	;einde databuffer
+	ld	(de),a	;end of data buffer
 
 edit_no_end:	ld	a,b
 	call	zettextblok
@@ -2994,7 +2994,7 @@ edit_ret_end:
 	JP	J53F9
 
 	;org 58f8
-Printret:	defb	0	;printen ? 1=ja
+Printret:	defb	0	;to print ? 1=yes
 
 _bufvol:
 	ld	de,(Regelnr)
@@ -3003,10 +3003,10 @@ _bufvol:
 	ld	a,#80
 	call	puttxtbuffer
 	ld	sp,(Edit_ret_sp)
-	jp	error1	;textbuffer vol
+	jp	error1	;text buffer full
 
 Lengtezin:	defb	0
-Reteinde:	defb	0	;0=niet einde, 1=einde
+Reteinde:	defb	0	;0=not end, 1=end
 
 
 ;----- BS
@@ -3043,7 +3043,7 @@ _edit_del2:	ld	d,h
 	jp	z,editorbestur
 	jp	editor_left
 
-;----- CTRL+B   Kopieer label
+;----- CTRL+B   Copy label
 copylabel:
 	call	testisblock
 	ld	bc,Noblock
@@ -3057,17 +3057,17 @@ copylabel:
 	ld	hl,Zin
 	LD	C,#FF
 	call	labeluitzin
-	jp	c,editorbestur	;geen label
+	jp	c,editorbestur	;no label
 	ld	a,(Editor_x)
 	add	a,b
 	cp	162
-	jp	nc,editorbestur	;past niet in regel
+	jp	nc,editorbestur	;does not fit in line
 	ld	hl,Label
 _copylabel1:
 	push	bc
 	push	hl
 	ld	a,(hl)
-	call	edit_letter1	;zet (Veranderd)=1
+	call	edit_letter1	;move (Changed)=1
 	ld	hl,Editor_x
 	inc	(hl)
 	pop	hl
@@ -3092,9 +3092,9 @@ J5999:	SUB	(HL)
 J59A8:	CALL	printscherm
 	jp	editorbestur
 
-;----- Haalt labeldefinitie uit zin op adres HL
-;----- IN: HL=beginadres (afgesloten met 0)
-;----- UIT: Label=label, B=lengte label, [C]=geen label aanwezig
+;----- Extracts label definition from sentence at address HL
+;----- IN: HL=start address (terminated with 0)
+;----- OUT: Label=label, B=length label, [C]=no label present
 labeluitzin:
 	ld	de,Label
 	ld	b,0
@@ -3135,7 +3135,7 @@ moveblock:
 	ld	de,Moving
 	jr	_copybl_cont
 
-;----- CTRL+K       Verwerkt ook CTRL+V !!!
+;----- CTRL+K       Also processes CTRL+V !!!
 copyblock:
 	xor	a
 	ld	de,Copying
@@ -3148,7 +3148,7 @@ _copybl_cont:
 	ld	b,d
 	ld	c,e
 	call	txttocomm
-	call	waarisblock	;A: 0=voor, 1=om, 2=na cursor
+	call	waarisblock	;A: 0=before, 1=at, 2=after cursor
 	ld	(Waarblok),a
 	cp	1
 	jp	z,cursorinblok
@@ -3177,16 +3177,16 @@ copycont:
 	ld	hl,Zin
 	ld	b,a
 	cp	1
-	jr	nz,_copyblock2	;geen lege zin
+	jr	nz,_copyblock2	;not an empty sentence
 	ld	a,(hl)
 	or	a
-	jr	z,_copyblock3	;lege zin
+	jr	z,_copyblock3	;empty sentence
 _copyblock2:	ld	a,(hl)
 	or	a
 	jr	nz,_copyblock1
 	ld	(hl)," "
 _copyblock1:	inc	hl
-	djnz	_copyblock2	;wis nullen
+	djnz	_copyblock2	;clear zeros
 	ld	(hl),0
 _copyblock3:
 	ld	a,(Oldbuffer)
@@ -3194,7 +3194,7 @@ _copyblock3:
 	call	insline1
 	xor	a
 	ld	(Printret),a
-	call	_return_cont	;naar REGELNR
+	call	_return_cont	;to REGELNR
 	ld	hl,(Regelnr)
 	inc	hl
 	ld	(Regelnr),hl
@@ -3261,14 +3261,14 @@ _copyeind1:
 	scf
 	sbc	hl,bc
 	jr	nc,_copyeind3
-	inc	hl	;regelnr <> 0
+	inc	hl	;line num <> 0
 _copyeind3:
 	inc	hl
 	ld	(Regelnr),hl
 	xor	a
 	ld	(Free_bekend),a
 	call	wiscommline
-	jp	_home_cont	;11 keer omhoog + printscherm + back
+	jp	_home_cont	;11 times up + print screen + back
 
 _moveeind:
 	ld	a,Bovenaantext
@@ -3294,7 +3294,7 @@ _moveeind2:
 	scf
 	sbc	hl,bc
 	jr	nc,_moveeind1
-	inc	hl	;regelnr <> 0
+	inc	hl	;line num <> 0
 _moveeind1:
 	inc	hl
 	ld	(Regelnr),hl
@@ -3302,17 +3302,17 @@ _moveeind1:
 	xor	a
 	ld	(Free_bekend),a
 	call	wiscommline
-	jp	_home_cont	;11 keer omhoog + printscherm + back
+	jp	_home_cont	;11 times up + print screen + back
 
 
 Copying:	defb	"Copying "
 Copybusy:	defb	"-",0
 Moving:	defb	"Moving  -",0
 Soort:	defb	0	;0=copy, 1=move
-Waarblok:	defb	0	;0=voor, 1=tussen, 2=na cursor
+Waarblok:	defb	0	;0=before, 1=between, 2=after cursor
 
 
-;----- 10 regels invoegen (shift+ins)
+;----- insert 10 lines (shift+ins)
 
 ins10line:
 	ld	b,10
@@ -3323,7 +3323,7 @@ _ins10line1:	push	bc
 	call	printscherm
 	jp	editorbestur
 
-;----- regel invoegen (ctrl+ins)
+;----- insert line (ctrl+ins)
 
 edit_insline:
 	call	insline1
@@ -3331,27 +3331,27 @@ edit_insline:
 	cp	15
 	jr	c,edit_inscnt
 	call	downschuif
-	jr	c,edit_inscnt	;kan niet
+	jr	c,edit_inscnt	;can not
 	call	upnormal
 edit_inscnt:	call	printscherm
 	jp	editorbestur
 insline1:
 	di
 	ld	de,(Laatsteregel)
-	call	geefadrrege1	;DE=laatst gebruikte data-adres
+	call	geefadrrege1	;DE=last used data address
 	ld	(Laatsteadres),de
 	ld	hl,Laatsteblok
 	ld	(hl),c
 	ld	b,1
-	call	freespace	;nog vrije ruimte ?
-	jp	c,error1	;textbuffer vol
-	ld	(hl),#80	;lege regel
+	call	freespace	;still free space?
+	jp	c,error1	;text buffer full
+	ld	(hl),#80	;empty line
 	ld	(Inslineadres),hl
-	ld	(Inslineblok),a	;later invullen
+	ld	(Inslineblok),a	;fill in later
 
 	ld	de,(Regelnr)
-	call	geefadrrege1	;DE=data-adres, C=data-bloknr (1-..)
-	ld	a,c	;bloknr
+	call	geefadrrege1	;DE=data address, C=data block number (1-..)
+	ld	a,c	;block number
 	push	af
 	push	de
 	call	insdat
@@ -3361,8 +3361,8 @@ insline1:
 	ret
 
 
-;-------------------- Insert data in databuffer
-;----- IN:  DE=Doeladres data, A=Doelblok data
+;-------------------- Insert data into data buffer
+;----- IN:  DE=Target address data, A=Target block data
 
 insdat:
 	ld	iy,Huidbl
@@ -3444,7 +3444,7 @@ movmid:
 	dec	hl
 	scf
 	sbc	hl,de
-	jr	c,_movm1	;lengte<1
+	jr	c,_movm1	;length<1
 	ld	b,h
 	ld	c,l
 	inc	bc
@@ -3470,7 +3470,7 @@ _puto1:
 	pop	de
 	ret
 
-Huidbl:	defb	0,0	;huidige blok, eindblok
+Huidbl:	defb	0,0	;current block, end block
 Eindad:	defw	#a000
 Laatsteadres:	defw	0
 Laatsteblok:	defb	0
@@ -3500,12 +3500,12 @@ backinsline:
 	ld	de,(Blokstart)
 	ld	a,d
 	or	e
-	ret	z	;geen blok
-	ld	hl,(Regelnr)	;hl=regelnr, de=begin blok
+	ret	z	;no block
+	ld	hl,(Regelnr)	;hl=line num, de=start block
 	call	rst20
 	jr	c,_incstart
 	jr	z,_incstart
-	ld	de,(Blokeinde)	;de=einde blok
+	ld	de,(Blokeinde)	;de=end block
 	call	rst20
 	jr	c,_inceinde
 	jr	z,_inceinde
@@ -3522,7 +3522,7 @@ Inslineadres:	defw	0
 Inslineblok:	defb	0
 
 
-;----- Verhoog/verlaag alle error-lines
+;----- Increase/decrease all error lines
 
 inserrorline:
 	ld	b,a
@@ -3737,7 +3737,7 @@ delblock:
 	ld	de,(Blokstart)
 	or	a
 	sbc	hl,de
-	inc	hl	;aantal regels
+	inc	hl	;number of lines
 	ld	b,h
 	ld	c,l
 
@@ -3777,7 +3777,7 @@ _delblock1:
 	ld	(Editor_y),a
 	ld	hl,0
 	ld	(Blokstart),hl
-	ld	(Blokeinde),hl	;blok gewist !
+	ld	(Blokeinde),hl	;block erased !
 	xor	a
 	ld	(Blokbuffer),a
 
@@ -3811,7 +3811,7 @@ delrestline:
 	CALL	J53F9
 	jp	editorbestur
 
-;----------- wis regel (CTRL+DEL)
+;----------- delete line (CTRL+DEL)
 
 edit_delline:
 	call	delline1
@@ -3822,7 +3822,7 @@ delline1:
 	call	edit_ret1
 	ld	de,(Regelnr)
 	call	geefadrregel
-	ret	c	;laatste regel
+	ret	c	;last line
 	push	de
 	push	af
 	call	zettextblok
@@ -3836,7 +3836,7 @@ _editdellin1:	call	gettxtbuffer
 	pop	de
 _editdellin2:	xor	a
 	call	puttxtbuffer
-	djnz	_editdellin2	;B tekens wissen
+	djnz	_editdellin2	;Delete B characters
 
 	ld	de,(Laatsteregel)
 	call	geefadrrege1
@@ -3844,14 +3844,14 @@ _editdellin2:	xor	a
 	ld	a,c
 	ld	(Laatsteblok),a
 	ld	de,(Regelnr)
-	call	geefadrrege1	;DE=data-adres, C=data-bloknr (1-..)
-	ld	a,c	;bloknr
+	call	geefadrrege1	;DE=data address, C=data block number (1-..)
+	ld	a,c	;block number
 	call	deldat
 	jp	dellineback
 
 
-;-------------------- Delete data uit databuffer
-;----- IN:  DE=Doeladres data, A=Doelblok data, BC=Lengte data
+;-------------------- Delete data from data buffer
+;----- IN: DE=Target address data, A=Target block data, BC=Length data
 
 deldat:
 	ld	(Dataad),de
@@ -3864,8 +3864,8 @@ deldat:
 	inc	hl
 	ld	(Einde),hl
 
-	ld	a,(iy)	;huidig blok
-	cp	(iy+1)	;=1e blok ?
+	ld	a,(iy)	;current block
+	cp	(iy+1)	;=1st block ?
 	ld	de,#8000
 	jr	nz,_deld2
 	ld	de,(Dataad)
@@ -3884,8 +3884,8 @@ _deld3:
 	dec	(iy)
 	ld	a,(iy)
 	call	zetdatablok
-	ld	a,(iy)	;huidig blok
-	cp	(iy+1)	;=1e blok ?
+	ld	a,(iy)	;current block
+	cp	(iy+1)	;=1st block ?
 	ld	de,#8000
 	jr	nz,_deld5
 	ld	de,(Dataad)
@@ -3920,7 +3920,7 @@ movmiddel:
 	sbc	hl,bc
 	scf
 	sbc	hl,de
-	jr	c,_movmdel1	;lengte<1
+	jr	c,_movmdel1	;length<1
 	inc	hl
 	push	hl
 	ld	h,d
@@ -3983,7 +3983,7 @@ dellineback:
 	call	decfkeylines
 
 	xor	a
-	ld	(Free_bekend),a	;nieuwe vrije ruimte ontstaan
+	ld	(Free_bekend),a	;new free space created
 
 	ld	a,(Blokbuffer)
 	ld	b,a
@@ -3993,11 +3993,11 @@ dellineback:
 	ld	de,(Blokstart)
 	ld	a,d
 	or	e
-	ret	z	;geen blok
-	ld	hl,(Regelnr)	;hl=regelnr, de=begin blok
+	ret	z	;no block
+	ld	hl,(Regelnr)	;hl=line num, de=start block
 	call	rst20
 	jr	c,_decstart
-	ld	de,(Blokeinde)	;de=einde blok
+	ld	de,(Blokeinde)	;de=end block
 	call	rst20
 	jr	c,_deceinde
 	jr	z,_deceinde
@@ -4013,28 +4013,28 @@ _deceinde:	ld	hl,(Blokeinde)
 	ret	nc
 	ld	hl,0
 	ld	(Blokstart),hl
-	ld	(Blokeinde),hl	;blok gewist
+	ld	(Blokeinde),hl	;block erased
 	ret
 
 Sp_editor:	defw	0
 
 
 
-;----- Zoek vrije ruimte in textbuffer met lengte B
-;----- UIT: [C] = geen ruimte gevonden, HL=adres, A=hoeveelste blok
-Free_bekend:	defb	0	;Adres bekend? 0=nee, 1=ja (voor vaker CTRL-INS)
+;----- Find free space in textbuffer with length B
+;----- OUT: [C] = no space found, HL=address, A=how many blocks
+Free_bekend:	defb	0	;Address known? 0=no, 1=yes (CTRL-INS for more often)
 Free_blok:	defb	0
-Free_adres:	defw	0	;laatste adres + blok
+Free_adres:	defw	0	;last address + block
 
 freespace:
 	ld	a,(Free_bekend)
 	or	a
-	jr	z,freespace1	;niet bekend
+	jr	z,freespace1	;not known
 	push	bc
 	call	freespace1
 	pop	bc
 	ret	nc
-	xor	a	;vooraan beginnen
+	xor	a	;start at the front
 	ld	(Free_bekend),a
 
 freespace1:
@@ -4053,11 +4053,11 @@ freespace1:
 	ld	b,h
 	ld	c,l
 	ex	de,hl
-	jr	_freespace2	;begin bij eindadres vorige keer
+	jr	_freespace2	;start at end address last time
 
-_nietbekend:	;begin bij begin buffer
+_nietbekend:	;start at start buffer
 	ld	a,1
-	call	zettextblok	;begin bij bloknr 1
+	call	zettextblok	;start at block number 1
 	ld	ix,Textbloknr
 _freespace1:
 	ld	hl,#8000
@@ -4068,13 +4068,13 @@ _freespace2:	xor	a
 _notspace:	ld	a,(Aantaltextbl)
 	cp	(ix)
 	scf
-	ret	z	;geen ruimte gevonden
+	ret	z	;no room found
 	ld	a,(ix)
 	inc	a
 	call	zettextblok
 	jr	_freespace1
 
-Aantalfree:	defb	0	;aantal te zoeken nullen
+Aantalfree:	defb	0	;number of zeros to search
 
 _spacefound:
 	dec	hl
@@ -4084,7 +4084,7 @@ _spacefound:
 _spacefound1:	ld	a,(hl)
 	inc	hl
 	or	a
-	jr	nz,_freespace2	;te kort
+	jr	nz,_freespace2	;shortage
 	dec	bc
 	ld	a,b
 	or	c
@@ -4092,7 +4092,7 @@ _spacefound1:	ld	a,(hl)
 	dec	d
 	jr	nz,_spacefound1
 	ld	a,1
-	ld	(Free_bekend),a	;voor volgende keer
+	ld	(Free_bekend),a	;for next time
 	ld	hl,(Spaceadress)
 	ld	a,(ix)
 	ld	(Free_adres),hl
@@ -4101,18 +4101,18 @@ _spacefound1:	ld	a,(hl)
 
 Spaceadress:	defw	0
 
-;----- bereken adres in vram  IN:Editor_y  UIT: HL=vramadres
-;----- Verandert: B,DE, HL, AF
+;----- calculate address in vram  IN:Editor_y  OUT: HL=vramaddress
+;----- Changes: B,DE, HL, AF
 bervram:
 	LD	A,(Editor_y)	;**********************************
-	LD	B,A	;korter! aangezien Edit_y>=4
+	LD	B,A	;shorter! since Edit_y>=4
 	LD	HL,-80
 	LD	DE,80
 _bervram	ADD	HL,DE
 	DJNZ	_bervram
 	RET
 
-;----- print info op scherm
+;----- print info on screen
 
 printinfoRnr	ld	de,(Regelnr)
 printinfoDE	ld	hl,25*80+7
@@ -4154,14 +4154,14 @@ Blockon:	defb	"[ ]",0
 printonoff:
 	ld	bc,On
 	or	a
-	jr	nz,_printonoff1	;***korter*********jp nz,printtekst
+	jr	nz,_printonoff1	;***shorter*********jp nz,printtekst
 	ld	bc,Off
 _printonoff1:	jp	printtekst
 
-Turbor:	defb	0	;is turbo-r ? 1=ja
+Turbor:	defb	0	;is turbo-r ? 1=yes
 
 
-;############################ Laad block file
+;########################### Load block file
 
 loadblock:
 	ld	hl,(Regelnr)
@@ -4176,28 +4176,28 @@ loadblock:
 Loadsaveblok:	defb	0
 Oldregelblk:	defw	0
 
-;############################ Laad ASCII file
+;############################ Load ASCII file
 Eindeload:	defb	0
-Blokload:	defb	0	;0=gewoon load, 1=blok load
+Blokload:	defb	0	;0=normal load, 1=block load
 
 loadascfile:
 	ld	(Used_fcb),de
 	call	ini_variabel
 	call	wisbuffer
 	xor	a
-	ld	(Blokload),a	;gewoon load
-	ld	ix,#8000	;Adres doel tekst
+	ld	(Blokload),a	;just load
+	ld	ix,#8000	;Address target text
 	ld	a,1
-	call	zetdatablok	;blok 1
-	ld	iy,#8000	;Adres adressen+blokken
+	call	zetdatablok	;block 1
+	ld	iy,#8000	;Address addresses+blocks
 	ld	a,1
 	call	zettextblok
 
 blokloadcont:
 	ld	(Sp_asciiload),sp
 	ld	a,1
-	ld	(Bronerrors),a	;errors van ascii laden
-	ld	de,(Bufferpage0)	;laden in page 0
+	ld	(Bronerrors),a	;load errors from ascii
+	ld	de,(Bufferpage0)	;load in page 0
 	push	de
 	push	ix
 	push	iy
@@ -4213,13 +4213,13 @@ blokloadcont:
 	LD	HL,(Used_fcb)
 	LD	DE,33
 	ADD	HL,DE
-	XOR	A	;*****recordnr, maar 2 bytes? ipv 4
+	XOR	A	;*****record number, only 2 bytes? instead of 4
 	LD	(HL),A
 	INC	HL
 	LD	(HL),A
 	ld	(Eindeload),a
 	ld	de,Zin
-;----- DE=doel in "Zin", IX=doel in textbuffer, IY=doel in databuffer
+;----- DE=target in "Sentence", IX=target in textbuffer, IY=target in databuffer
 _volgendblok:
 	ld	(Zinadres),de
 	ld	a,(Eindeload)
@@ -4230,12 +4230,12 @@ _volgendblok:
 	ld	c,#27
 	push	ix
 	push	iy
-	call	bdos	;laad blok
+	call	bdos	;load block
 	ld	b,h
-	ld	c,l	;BC = werkelijke lengte
+	ld	c,l	;BC = actual length
 	pop	iy
-	pop	ix	;Doeladres textbuffer
-	ld	(Eindeload),a	;<>0 => laatste keer
+	pop	ix	;Destination address text buffer
+	ld	(Eindeload),a	;<>0 => last time
 
 	ld	de,(Zinadres)
 	ld	hl,(Bufferpage0)
@@ -4259,18 +4259,18 @@ _loadeind:
 	push	hl
 	push	bc
 	ld	a,(Textbloknr)
-	ld	(Blokbuff),a	;huidig blok (voor data)
+	ld	(Blokbuff),a	;current block (for data)
 	xor	a
-	ld	(de),a	;einde zin aangeven
+	ld	(de),a	;indicate end of sentence
 
 	ld	a,(Blokload)
 	or	a
-	jp	nz,contblokload	;ga verder bij blok load
+	jp	nz,contblokload	;continue at block load
 
 	ld	(Lastdatadres),iy
 	ld	a,(Databloknr)
-	ld	(Lastdatblok),a	;voor "Datbuf too small" !
-	call	makeline	;maak zin met tabs
+	ld	(Lastdatblok),a	;for "Datbuf too small" !
+	call	makeline	;make sentence with tabs
 	call	huidigtxtblk
 	push	ix
 	pop	de
@@ -4280,11 +4280,11 @@ _loadeind1:	ld	a,(hl)
 	inc	hl
 	call	puttxtbuffer
 	and	%10000000
-	jr	z,_loadeind1	;zin naar buffer
+	jr	z,_loadeind1	;sentence to buffer
 	push	de
 	pop	ix
 
-	push	iy	;vul datablok in
+	push	iy	;fill in data block
 	pop	de
 	call	huidigdatblk
 	ld	a,(Blokbuff)
@@ -4314,8 +4314,8 @@ Adresbuffer:	defw	0
 contblokload:
 	call	insline1
 	xor	a
-	ld	(Printret),a	;niet printen bij return
-	call	_return_cont	;naar REGELNR
+	ld	(Printret),a	;do not print on return
+	call	_return_cont	;to REGELNR
 	ld	hl,(Regelnr)
 	ld	(Blokeinde),hl
 	inc	hl
@@ -4335,11 +4335,11 @@ _eindefile:
 	jp	closefile
 _eindefile1:
 	call	huidigdatblk
-	ld	(iy),#ff	;Einde adressen
+	ld	(iy),#ff	;End addresses
 	jp	closefile
 
 
-Zinadres:	defw	0	;Huidige adres in "Zin"
+Zinadres:	defw	0	;Current address in "Sentence"
 Lengte_low:	defw	0
 Lengte_high:	defw	0
 
@@ -4401,23 +4401,23 @@ contsaveblok:
 _nextsavereg:	ld	de,(Saveline)
 	inc	de
 	ld	(Saveline),de
-	call	geefadrregel	;a=bloknr, de=adres
-	jr	c,endsavefile	;einde
+	call	geefadrregel	;a=block number, de=address
+	jr	c,endsavefile	;end
 	call	zettextblok
 
 	ld	a,(Bloksave)
 	or	a
 	call	nz,testendblk
-	jr	c,endsavefile	;einde block
+	jr	c,endsavefile	;end block
 
-	ld	hl,(Savebufadres)	;hl=adres buffer
+	ld	hl,(Savebufadres)	;hl=address buffer
 _nextsavetek:	call	gettxtbuffer
 	bit	7,a
 	jr	nz,_saveendzin
 	call	tosavebuffer
 	jr	_nextsavetek
 _saveendzin:	and	%01111111
-	call	nz,tosavebuffer	;0 niet saven
+	call	nz,tosavebuffer	;0 do not save
 	ld	a,#0d
 	call	tosavebuffer
 	ld	a,#0a
@@ -4427,11 +4427,11 @@ _saveendzin:	and	%01111111
 
 endsavefile:
 	ld	hl,(Savebufadres)
-	ld	a,#1a	;einde file
+	ld	a,#1a	;end of file
 	call	tosavebuffer
 	ld	bc,(Bufferpage0)
 	or	a
-	sbc	hl,bc	;lengte
+	sbc	hl,bc	;length
 	ld	a,h
 	or	l
 	jr	z,_endsave1
@@ -4469,7 +4469,7 @@ savedisk:
 	push	ix
 	ld	de,(Used_fcb)
 	ld	c,#26
-	call	bdos	;tussentijds saven
+	call	bdos	;interim save
 	pop	ix
 	pop	iy
 	or	a
@@ -4503,7 +4503,7 @@ loaddisk:
 	pop	iy
 	ret
 
-;----- Load assemblerfile
+;----- Load assembler file
 
 Doinclude:	defb	0
 
@@ -4538,11 +4538,11 @@ _loadasm1:
 	ld	a,(Aantaltextbl)
 	inc	(iy)
 	cp	(iy)
-	jp	c,goerror1	;textbuffer te klein
+	jp	c,goerror1	;text buffer too small
 	ld	a,(Aantaldatabl)
-	inc	(iy+3)	;=iy+4 (vanwege inc iy)
+	inc	(iy+3)	;=iy+4 (because of inc iy)
 	cp	(iy+3)
-	jp	c,goerror2	;databuffer te klein
+	jp	c,goerror2	;data buffer too small
 	ld	de,#8000
 	call	setdma
 
@@ -4557,7 +4557,7 @@ _nexttextloa:
 	ld	a,(Txtslt)
 	cp	(hl)
 	ld	hl,zettextblok
-	jr	nz,_specialload	;in ander slot laden   
+	jr	nz,_specialload	;load in another slot
 	call	loadblok
 	pop	bc
 	jr	c,loadcont
@@ -4580,7 +4580,7 @@ _nextdataloa:
 	ld	a,(Datslt)
 	cp	(hl)
 	ld	hl,zetdatablok
-	jr	nz,_specialloa1	;in ander slot laden
+	jr	nz,_specialloa1	;load in another slot
 	call	loadblok
 	pop	bc
 	jr	c,loadcont1
@@ -4600,7 +4600,7 @@ loadcont1:
 	xor	a
 	ret
 
-;----- laad blok in standaard ram
+;----- load block in standard ram
 
 loadblok:
 	dec	(iy)
@@ -4620,7 +4620,7 @@ _loadlast:
 	scf
 	ret
 
-;----- laad blok in externe mapper
+;----- load block in external mapper
 
 loadspecial:
 	ld	(Specialload1+1),hl
@@ -4645,8 +4645,8 @@ _load4000:
 	call	loaddisk
 	ld	a,(#bfff)
 	ld	(Errorspec+1),a
-Specialload:	ld	a,0	;INGEVULD !!!
-Specialload1:	call	0	;INGEVULD !!!
+Specialload:	ld	a,0	;FILLED IN !!!
+Specialload1:	call	0	;FILLED IN !!!
 	pop	bc
 	di
 	ld	a,(Labelbuffers+1)
@@ -4655,13 +4655,13 @@ Specialload1:	call	0	;INGEVULD !!!
 	ld	de,#8000
 	ldir
 Errorspec:	ld	a,0
-	ld	(#bfff),a	;#FFFF niet uit te lezen !
+	ld	(#bfff),a	;#FFFF unreadable !
 	xor	a
 	out	(#ff),a
 _loadasm_end:
 	pop	af
 	scf
-	ret	z	;Laatste
+	ret	z	;Last
 	ccf
 	ret
 
@@ -4697,7 +4697,7 @@ _goerror2_1:
 	jp	(hl)
 
 
-;----- Save assemblerfile
+;----- Save assembler file
 
 saveasmfile:
 	ld	(Used_fcb),de
@@ -4746,7 +4746,7 @@ J6534:	CALL	gettxtbuffer
 	INC	(IY+#01)
 J6544:	LD	A,(IY+#01)
 	dec	a
-	ld	(iy+3),a	;aantal hele
+	ld	(iy+3),a	;number of whole
 	ld	(iy),1
 	RES	7,D
 	LD	(Lengtelast),DE
@@ -4769,7 +4769,7 @@ J6544:	LD	A,(IY+#01)
 	ld	bc,9
 	ldir
 	ld	hl,9
-	call	savedisk	;header saven
+	call	savedisk	;save header
 
 	ld	de,#8000
 	call	setdma
@@ -4820,7 +4820,7 @@ C65E0:	LD	A,(IY+#00)
 	LD	BC,#8000
 	RET
 
-;----- save blok uit standaard ram
+;----- save block from standard ram
 
 saveblok:
 	ld	a,(iy)
@@ -4837,7 +4837,7 @@ _savelast:
 	scf
 	ret
 
-;----- save blok uit externe mapper
+;----- save block from external mapper
 
 savespecial:
 	xor	a
@@ -4859,7 +4859,7 @@ _save4000:
 	dec	hl
 _onder4000:
 	di
-	ld	a,(Labelbuffers+1)	;holala, gewaagd!!!!***********
+	ld	a,(Labelbuffers+1)	;holala, daring!!!!***********
 	out	(#ff),a
 	ld	b,h
 	ld	c,l
@@ -4874,46 +4874,46 @@ _onder4000:
 	ld	h,#80
 	call	slot
 	ld	a,(Labelbuffers+1)
-	CALL	#0131	;zelfde als out fe,a
+	CALL	#0131	;same as out fe,a
 	pop	af
-	ld	(#bfff),a	;#FFFF niet te schrijven !!!
+	ld	(#bfff),a	;#FFFF not to write !!!
 	pop	hl
 	call	savedisk
 _saveasm_end:
 	pop	af
 	scf
-	ret	z	;laatste
+	ret	z	;last
 	ccf
 	ret
 
-	;zou zijn op 665A**************************************
+	;would be at 665A**************************************
 
 Saveblok:	defb	0
 Lastblok:	defb	0	;iy+1
 
 Headerasm:	defb	#fc
-Aantalhele:	defb	0	;iy+2 text  Header begint hier !
+Aantalhele:	defb	0	;iy+2 text Header starts here !
 Lengtelast:	defw	0	;iy+3 text
 Aantalhele1:	defb	0	;data
 Lengtelast1:	defw	0	;data
-Laatstergl:	defw	0	;laatste regelnr.
+Laatstergl:	defw	0	;last line num.
 
 ;org 6665
 
-;----- Maak van "Zin" een zin met tabs enz. "Zin" afgesloten met een 0
-;----- UIT: A=lengte doel, Zin in "Zin"+161 (Eindigt met bit 7 hoog)
+;----- Make "Sentence" a sentence with tabs etc. "Sentence" ended with a 0
+;----- OUT: A=Length target, Sentence in "Sentence"+161 (Ends with bit 7 high)
 
 makeline:
 	push	bc
 	push	iy
 	xor	a
-	ld	(Aanhaling),a	;Aanhalingstekens uit
+	ld	(Aanhaling),a	;quotes off
 	ld	(Puntkomma),a
-	ld	a,#80	;lege Zin
+	ld	a,#80	;empty Sentence
 	ld	(Zin+161),a
-	ld	hl,Zin	;lengte Zin=160+zero
+	ld	hl,Zin	;length Sentence=160+zero
 	ld	de,Zin+161-1
-	ld	c,0	;Positie 0
+	ld	c,0	;Position 0
 _makeline2:
 	ld	a,c
 	cp	161
@@ -4954,20 +4954,20 @@ _makeline2:
 
 _natab:	inc	de
 	ld	(de),a
-	jr	_makeline2	;Volgende
+	jr	_makeline2	;Next one
 
 _killspace:
 	ex	af,af'
 	ld	a,(Tabsonoff)
 	or	a
 	ld	a," "
-	jr	z,_natab	;tabs off, dus gewoon spatie
+	jr	z,_natab	;tabs off, so just space
 	ld	a,(Aanhaling)
 	ld	b,a
 	ld	a,(Puntkomma)
 	or	b
 	ld	a," "
-	jr	nz,_natab	;aanhalingstekens of puntkomma aan
+	jr	nz,_natab	;quotes or semicolon
 	ex	af,af'
 _killspace1:
 	ld	b,a
@@ -5016,12 +5016,12 @@ _aanhali1:
 	and	%11011111
 	cp	"F"
 	ld	a,"'"
-	jr	z,_natab	;' hoort bij ex af,af'
+	jr	z,_natab	;'belongs to ex af,af'
 _aanhali2:
 	ld	a,b
 	ld	(Aanhaling),a
 	jr	_natab
-Aanhaling:	defb	0	;Aanhalingsteken: 0=uit, " of '=aan
+Aanhaling:	defb	0	;Quotation mark: 0=off, " or '=on
 
 _puntkomma:
 	ld	a,(Aanhaling)
@@ -5033,13 +5033,13 @@ _puntkomma:
 	xor	1	;1=off
 	or	b
 	ld	a,";"
-	jr	nz,_natab	;";" of aanhalingstekens of tabs off
+	jr	nz,_natab	;";" or quotes or tabs off
 	ld	a,1
 	ld	(Puntkomma),a
 	inc	c
 	ld	a,c
 	cp	2
-	jr	z,_0keertab	;vooraan zin
+	jr	z,_0keertab	;front sentence
 	ld	a,(de)
 	cp	" "
 	jr	z,_1keertab
@@ -5083,7 +5083,7 @@ _maketab1:
 
 _endofline:
 	ex	de,hl
-	set	7,(hl)	;Zin+160 overschreven bij lege lijn!!!
+	set	7,(hl)	;Sentence+160 overwritten on empty line!!!
 	ld	de,0-(Zin+161-1)
 	add	hl,de
 	ld	a,l
@@ -5092,7 +5092,7 @@ _endofline:
 	ret
 
 
-;******************************   DISKROUTINES
+;******************************   DISK ROUTINES
 
 setdma:
 	push	iy
@@ -5102,7 +5102,7 @@ setdma:
 	ret
 
 
-;############################ Print regels op scherm
+;########################### Print lines on screen
 printscherm:	LD	HL,3*80
 	CALL	setvramwrite
 	ld	hl,(Regelnr)
@@ -5112,7 +5112,7 @@ printscherm:	LD	HL,3*80
 	ld	d,0
 	xor	a
 	sbc	hl,de
-	ex	de,hl	;DE=regelnummer bovenaan
+	ex	de,hl	;DE=line number at the top
 	PUSH	DE
 	LD	B,22
 J679C:	DI
@@ -5220,10 +5220,10 @@ J6851:	LD	HL,v_jon1
 v_jon1	ds	10,0
 v_jon2	db	#80,0,0,0,0,0,0,0,0,#01
 
-;volgende uitleg klopt eventueel niet
-;######################## Haal zin uit buffer  IN: DE=regelnummer
-;             UIT: Zin, [C] is einde text, A=lengte zin (bij [NC])
-;       VERANDERT: Alles, behalve IX
+;the following explanation may not be correct
+;######################## Get sentence from buffer  IN: DE=line number
+;             OUT: Sentence, [C] is end of text, A=length sentence (with [NC])
+;       CHANGES: Everything except IX
 
 _haalzinjon	dw	0
 
@@ -5275,7 +5275,7 @@ J68AD:	INC	HL
 _voertabuit:
 	ld	a,160+1
 	sub	b
-	ld	c,a	;C = huidige positie 0-80
+	ld	c,a	;C = current position 0-80
 	ld	iy,Tabs
 _voertabuit2:	ld	a,(iy)
 	inc	iy
@@ -5288,7 +5288,7 @@ _voertabuit1:
 	ld	c,a
 	ld	b,0
 	ld	hl,(_haalzinjon)
-	add	hl,bc	;HL = nieuwe positie in zin
+	add	hl,bc	;HL = new position in sentence
 	LD	A,L
 	EXX
 	INC	B
@@ -5305,9 +5305,9 @@ Tabs:	defb	14,22,39,47,55,63,71,79,87,95
 
 
 ;####################################
-;Geef adres bij regel   IN: DE=regel
-;UIT: [C]=einde tekst, DE=adres text, A=hoev. textblok
-;Verandert: HL,DE,AF,BC
+;Enter address at line   IN: DE=line
+;OUT: [C]=end text, DE=address text, A=quantity. text block
+;Changes: HL,DE,AF,BC
 
 geefadrregel:
 	call	geefadrrege1
@@ -5328,13 +5328,13 @@ geefadrregel:
 	ret
 
 	;ORG #6910
-;IN : DE=regelnummer
-;UIT: DE=adres databuffer, C=hoeveelste blok databuffer
+;IN : DE=line number
+;OUT: DE=address data buffer, C=how many blocks of data buffer
 
 geefadrrege1:
 	dec	de
-	ld	c,1	;1e blok
-	ld	hl,0	;1e adres (eigenlijk #8000)
+	ld	c,1	;1st block
+	ld	hl,0	;1st address (actually #8000)
 	ld	b,3
 _geefadrreg3:	add	hl,de
 _geefadrreg2:	ld	a,h
@@ -5349,17 +5349,17 @@ _geefadrreg1:	djnz	_geefadrreg3
 	ex	de,hl
 	ret
 
-;############################ Kleine subroutines
+;########################### Small subroutines
 
-;----- Schakelt huidige textblok
-;----- Verandert: AF
+;----- Toggles current text block
+;----- Changes: AF
 
 huidigtxtblk:
 	ld	a,(Textbloknr)
-;Textblokreal: defb    0                ;Huidig textblok (#fe-waarde)
+;Textblokreal: defb    0                ;Current textblock (#fe value)
 
-;----- IN: A = Blocknr van tekstbuffer (1-..)
-;----- Verandert: AF
+;----- IN: A = Block number of text buffer (1-..)
+;----- Changes: AF
 
 zettextblok:
 	ld	(Textbloknr),a
@@ -5378,10 +5378,10 @@ _zettextblo1:
 	ld	(Txtslt),a
 	jr	_korterjon
 
-Txtslt:	defb	0	;gebruikt bij assemblerfile laden
+Txtslt:	defb	0	;used when loading assembler file
 
-;----- IN: A = Blocknr van labelbuffer (1-..)
-;----- Verandert: AF
+;----- IN: A = Block number of label buffer (1-..)
+;----- Changes: AF
 
 zetlabblok:
 	ld	(Labbloknr),a
@@ -5399,17 +5399,17 @@ _zetlabblo1:
 	ld	a,(hl)
 	jr	_korterjon
 
-;Labblokreal:  defb    0                ;Huidig labelblok (#fe-waarde)
+;Labblokreal:  defb    0                ;Current label block (#fe value)
 
-;----- Schakelt huidige datablok
-;----- Verandert: AF
+;----- Switches current data block
+;----- Changes: AF
 
 huidigdatblk:
 	ld	a,(Databloknr)
-;Datablokreal: defb    0                ;Huidig datablok (#fe-waarde)
+;Datablokreal: defb    0                ;Current data block (#fe value)
 
-;----- IN: A = Blocknr van databuffer (1-..)
-;----- Verandert: AF
+;----- IN: A = Block number of data buffer (1-..)
+;----- Changes: AF
 
 zetdatablok:
 	ld	(Databloknr),a
@@ -5417,7 +5417,7 @@ zetdatablok:
 	push	hl
 	ld	hl,Databuffers-1
 	add	a,l
-	ld	l,a	;is eig niet nodig*****want +-#3f40
+	ld	l,a	;is not necessary*****because +-#3f40
 	jr	nc,_zetdatablo1
 	inc	h
 _zetdatablo1:
@@ -5431,10 +5431,10 @@ _korterjon	ld	h,#80
 	pop	hl
 	ret
 
-Datslt:	defb	0	;voor assemblerfile laden
+Datslt:	defb	0	;load for assembler file
 
-;----- 1 byte naar textbuffer + eventueel: verhoog buffer
-;----- IN: DE=adres
+;----- 1 byte to textbuffer + optionally: increase buffer
+;----- IN: DE=address
 
 puttxtbuffer:
 	ld	(de),a
@@ -5446,7 +5446,7 @@ puttxtbuffer:
 	ld	hl,Textbloknr
 	ld	a,(Aantaltextbl)
 	cp	(hl)
-	jp	z,error1	;textbuffer vol
+	jp	z,error1	;text buffer full
 	inc	(hl)
 	ld	a,(hl)
 	call	zettextblok
@@ -5455,8 +5455,8 @@ _korterjon2	pop	hl
 	res	6,d
 	ret
 
-;----- 1 byte van labelbuffer + verhoog bufferblok indien nodig
-;----- IN: DE=adres
+;----- 1 byte of label buffer + increase buffer block if necessary
+;----- IN: DE=address
 getlabbuffer:
 	ld	a,(de)
 	inc	de
@@ -5467,14 +5467,14 @@ getlabbuffer:
 	ld	hl,Labbloknr
 	ld	a,(Aantallabelb)
 	cp	(hl)
-	jr	z,_getlabbuff1	;einde labelbuffer
+	jr	z,_getlabbuff1	;end of label buffer
 	inc	(hl)
 	ld	a,(hl)
 	call	zetlabblok
 _getlabbuff1:	jr	_korterjon2	;*******************************
 
-;----- 1 byte van textbuffer + verhoog bufferblok indien nodig
-;----- IN: DE=adres
+;----- 1 byte of textbuffer + increase buffer block if necessary
+;----- IN: DE=address
 gettxtbuffer:
 	ld	a,(de)
 	inc	de
@@ -5485,14 +5485,14 @@ gettxtbuffer:
 	ld	hl,Textbloknr
 	ld	a,(Aantaltextbl)
 	cp	(hl)
-	jr	z,_gettxtbuff1	;textbuffer vol
+	jr	z,_gettxtbuff1	;text buffer full
 	inc	(hl)
 	ld	a,(hl)
 	call	zettextblok
 _gettxtbuff1:	jr	_korterjon2
 
-;----- 1 byte naar databuffer + eventueel: verhoog buffer
-;----- IN: DE=adres
+;----- 1 byte to data buffer + optionally: increase buffer
+;----- IN: DE=address
 
 putdatbuffer:
 	ld	(de),a
@@ -5504,14 +5504,14 @@ putdatbuffer:
 	ld	hl,Databloknr
 	ld	a,(Aantaldatabl)
 	cp	(hl)
-	jp	z,error2	;databuffer vol
+	jp	z,error2	;data buffer full
 	inc	(hl)
 	ld	a,(hl)
 	call	zetdatablok
 	jr	_korterjon2
 
-;----- 1 byte van databuffer + verhoog bufferblok indien nodig
-;----- IN: DE=adres
+;----- 1 byte of data buffer + increase buffer block if necessary
+;----- IN: DE=address
 getdatbuffer:
 	ld	a,(de)
 	inc	de
@@ -5522,13 +5522,13 @@ getdatbuffer:
 	ld	hl,Databloknr
 	ld	a,(Aantaldatabl)
 	cp	(hl)
-	jr	z,_getdatbuff1	;databuffer vol
+	jr	z,_getdatbuff1	;data buffer full
 	inc	(hl)
 	ld	a,(hl)
 	call	zetdatablok
 _getdatbuff1:	jr	_korterjon2	;****************************
 
-;----- Vergelijk HL met DE
+;----- Compare HL with DE
 rst20:
 	ld	a,h
 	sub	d
@@ -5537,7 +5537,7 @@ rst20:
 	sub	e
 	ret
 
-;********** SUBROUTINE'S
+;********** SUBROUTINES
 
 beep:
 	push	af
@@ -5562,14 +5562,14 @@ putr800:	ld	ix,#180
 	jp	gobios
 
 
-;########################## Fout-afhandeling
+;########################## Error Handling
 
-;-------------------- ASCII LADEN
+;-------------------- ASCII LOAD
 
 Bronerrors:	defb	0	;0=editor,1=ascii,2=debuggerline
 
 
-error1:	;Textbuffer vol
+error1:	;Text buffer full
 	ld	bc,Txtbuf_full
 _error1_2:
 	ld	hl,(80-20)/2+80*Commline
@@ -5602,7 +5602,7 @@ _loadfout1:
 	ld	a,(Lastdatblok)
 	call	zetdatablok
 	ld	hl,(Lastdatadres)
-	ld	(hl),#ff	;einde datablok
+	ld	(hl),#ff	;end of data block
 	jp	closefile
 Lastdatblok:	defb	0
 Lastdatadres:	defw	0
@@ -5613,12 +5613,12 @@ _editorfout1:	ld	sp,(Sp_editor)
 Sp_asciiload:	defw	0
 Txtbuf_full:	defb	"Sourcebuffer too small",0
 
-error2:	;Databuffer vol
+error2:	;Data buffer full
 	ld	bc,Datbuf_full
 	jr	_error1_2
 Datbuf_full:	defb	"Databuffer too small",0
 
-;------ Show labels op scherm
+;------ Show labels on screen
 
 ;Aantallabels: defw    0
 ;Huidiglabel:  defw    1
@@ -5631,7 +5631,7 @@ Showlab1ek:	defb	1
 Orig:	equ	kbuf+100	;*************************
 Test:	equ	kbuf+125	;**************************
 Oudtest:	equ	kbuf+150	;**************************
-Showlabels:	defb	0	;0=off, 1=on (off na GO)
+Showlabels:	defb	0	;0=off, 1=on (off after GO)
 
 !labels:
 showlabels:
@@ -5652,7 +5652,7 @@ showlabels:
 	jp	z,prtnolab
 	call	GOgeeflabdat
 	ld	a,#ff
-	ld	(kbuf+27*3+2),a	;einde markering***********************
+	ld	(kbuf+27*3+2),a	;end of mark***********************
 	ld	a,h
 	or	l
 	jp	z,prtnolab
@@ -5743,7 +5743,7 @@ showlabdown:
 	ld	hl,Oudtest
 	ld	de,Orig
 	ld	bc,21
-	ldir		;laatste
+	ldir		;last
 	ld	a,#ff
 	ld	(Oudtest),a
 	call	haal1groter
@@ -5770,7 +5770,7 @@ labup:
 	inc	(iy)
 	ld	a,h
 	or	l
-	jp	z,showlabhoofd	;1e pag. bovenaan
+	jp	z,showlabhoofd	;1st page at the top
 	ld	(iy),18
 labupctrl:
 	call	showlabup
@@ -5786,7 +5786,7 @@ showlabup:
 	jp	printlabels
 
 
-showlabini:	;1e keer
+showlabini:	;1st time
 	ld	(Laboptie),a	;1
 	dec	a	;0
 	ld	(Showlab1ek),a
@@ -5826,7 +5826,7 @@ _showlabsp3:
 	JR	Z,J6C3B
 	LD	C,#DF
 J6C3B	call	labeluitzin
-	jr	c,_showlabsp4	;geen label
+	jr	c,_showlabsp4	;no label
 	ld	hl,Label
 	ld	de,Register2
 _showlabsp5:
@@ -5964,8 +5964,8 @@ berbalk:
 
 ;----- Subroutines show labels
 
-haal1groter:	;Orig = kbuf+100, Test = kbuf+125, Oudtest = kbuf+150************
-;              gaat door totdat: test > orig & test < oudtest      ************
+haal1groter:	;Orig = kbuf+100, Test = kbuf+125, Oldtest = kbuf+150************
+;              continues until: test > orig & test < oldtest      ************
 	ld	ix,(Lab_lijst)
 	ld	a,(ix+2)
 	cp	#ff
@@ -5973,7 +5973,7 @@ haal1groter:	;Orig = kbuf+100, Test = kbuf+125, Oudtest = kbuf+150************
 	ld	a,(Oudtest)
 	inc	a
 	scf
-	ret	z	;einde buffer en niet gevonden
+	ret	z	;end of buffer and not found
 	xor	a
 	ret
 _haal1gr1:
@@ -5991,12 +5991,12 @@ _haal1gr2:
 	ld	de,Oudtest
 	ld	hl,Test
 	call	testgroter
-	jr	c,_haal1gr_nfd	;test > oudtest    OK
+	jr	c,_haal1gr_nfd	;test > old test    OK
 _haal1gr_fnd:
 	ld	hl,Test
 	ld	de,Oudtest
 	ld	bc,21
-	ldir		;maak oudtest = test
+	ldir		;make oldtest = test
 	ld	hl,Tijd_srt
 	ld	de,Lab_soort
 	ld	bc,6
@@ -6055,13 +6055,13 @@ Lab_waarde:	defw	0
 Lab_adres:	defw	0
 Lab_blk:	defb	0
 Lab_lijst:	defw	0
-Next:	defs	3	;adres+blok volgende
+Next:	defs	3	;address+block next
 Tijd_srt:	defb	0
 Tijd_wrd:	defw	0
 Tijd_adr:	defw	0
 Tijd_blk:	defb	0
 
-;--- Test of de > hl
+;--- Test whether de > hl
 
 testgroter:
 	ld	a,(de)
@@ -6071,7 +6071,7 @@ testgroter:
 	ret	c	;de<hl
 	jr	nz,_testgr_fnd	;de>hl
 	or	a
-	jr	nz,testgroter	;tot nu toe gelijk
+	jr	nz,testgroter	;so far right
 	scf		;de=hl
 	ret
 _testgr_fnd:
@@ -6083,11 +6083,11 @@ GOgeeflabdat:
 	ld	hl,geeflabdata
 	jp	gotoass
 
-;------ Print errors op scherm
+;------ Print errors on screen
 
 
 printerrors1:
-	call	edit_ret1	;voor ctrl-r aanroep
+	call	edit_ret1	;for ctrl-r call
 !errors:
 printerrors:
 	ld	hl,3*80+18
@@ -6254,16 +6254,16 @@ _prtnoerr1:
 	jp	editor_cont
 Noerrors:	defb	"No errors !",0
 
-;---------- Zoekfunktie
+;---------- Search function
 
 dosearch:
 	ld	de,(Regelnr)
-	ld	(Searchstart),de	;beginregel
+	ld	(Searchstart),de	;opening line
 	ld	(Searchregel),de
 	bit	0,(iy+1)
 	jp	z,s_vooruit
 
-;----- Zoek achteruit
+;----- Search backwards
 
 s_achteruit:
 	push	de
@@ -6276,17 +6276,17 @@ s_achteruit:
 	ld	a,d
 	or	e
 	scf
-	ret	z	;1e regel = einde buffer
-	jr	s_achternx2	;einde buffer
+	ret	z	;1st line = end of buffer
+	jr	s_achternx2	;end of buffer
 s_achternx3:
-	ld	(iy-1),a	;lengte regel (1-80)
+	ld	(iy-1),a	;length line (1-80)
 	ld	a,(Editor_x)
 	ld	e,a
 	ld	d,0
-	ld	hl,Zin-2	;vorige karakter
+	ld	hl,Zin-2	;previous character
 	add	hl,de
 	dec	a
-	ld	c,a	;huidige positie (1-80)
+	ld	c,a	;current position (1-80)
 	jr	s_achter3
 
 s_achternxt:
@@ -6310,16 +6310,16 @@ s_achternx1:
 	pop	iy
 	ld	(iy-1),a
 	ld	c,a
-	ld	hl,Zin-1	;ZO LATEN !!!
+	ld	hl,Zin-1	;LEAVE IT !!!
 	ld	e,a
 	ld	d,0
-	add	hl,de	;laatste karakter
+	add	hl,de	;last character
 s_achter3:
 	ld	de,Searchtext
 s_achter2:
 	ld	a,c
 	or	a
-	jr	z,s_achternxt	;vorige regel
+	jr	z,s_achternxt	;previous line
 	ld	a,(hl)
 	dec	hl
 	dec	c
@@ -6333,31 +6333,31 @@ s_achter2:
 	push	bc
 	inc	hl
 	inc	hl
-	inc	c	;niet 2 keer, want begint bij 1 te tellen !
+	inc	c	;not 2 times, because counting starts at 1 !
 	call	testrest
 	pop	bc
 	pop	hl
 	inc	hl
 	ret	nc
 	dec	hl
-	jr	s_achter3	;zoek verder in deze zin
+	jr	s_achter3	;search further in this sentence
 
 
-;----- Zoek vooruit
+;----- Search ahead
 
 s_vooruit:
 	push	iy
 	call	haalzinzin
 	pop	iy
 	ld	de,1
-	jr	c,s_vooruitnx2	;einde buffer
-	ld	(iy-1),a	;lengte regel (1-80)
+	jr	c,s_vooruitnx2	;end of buffer
+	ld	(iy-1),a	;length rule (1-80)
 	ld	a,(Editor_x)
 	ld	e,a
 	ld	d,0
 	ld	hl,Zin
-	add	hl,de	;volgende karakter
-	ld	c,a	;huidige positie (0-79)
+	add	hl,de	;next character
+	ld	c,a	;current position (0-79)
 	jr	s_vooruit3
 
 s_vooruitnxt:
@@ -6375,13 +6375,13 @@ s_vooruitnx1:
 	jr	c,s_vooruitnx2
 	ld	(iy-1),a
 	ld	c,0
-	ld	hl,Zin	;ZO LATEN !!!
+	ld	hl,Zin	;LEAVE IT !!!
 s_vooruit3:
 	ld	de,Searchtext
 s_vooruit2:
 	ld	a,c
 	cp	(iy-1)
-	jr	nc,s_vooruitnxt	;volgende regel
+	jr	nc,s_vooruitnxt	;next line
 	ld	a,(hl)
 	inc	hl
 	inc	c
@@ -6399,7 +6399,7 @@ s_vooruit2:
 	dec	hl
 	ret	nc
 	inc	hl
-	jr	s_vooruit3	;zoek verder in deze zin
+	jr	s_vooruit3	;search further in this sentence
 
 testrest:
 	inc	de
@@ -6444,7 +6444,7 @@ testrond:
 Searchstart:	defw	0
 Searchregel:	defw	0
 
-;---------- Plaats scherm en cursor op searchstring
+;---------- Place screen and cursor on searchstring
 
 searchcursor:
 	ld	(Searchplaats),hl
@@ -6490,7 +6490,7 @@ _search_cur2:
 	ld	(Cursoronoff),a
 	jp	printscherm
 
-;----- Vervang tekst
+;----- Replace text
 
 doreplace:
 	ld	hl,80*Commline+(80-15)/2
@@ -6509,7 +6509,7 @@ doreplace:
 	call	haalzinzin
 	INC	HL
 	LD	(HL),#FF
-	ld	hl,(Searchplaats)	;moet 71ab zijn***********************
+	ld	hl,(Searchplaats)	;must be 71ab***********************
 	ld	de,Zin
 	or	a
 	sbc	hl,de
@@ -6529,9 +6529,9 @@ _doreplace2:
 	inc	hl
 	or	a
 	jr	nz,_doreplace2
-	push	hl	;rest bron
+	push	hl	;rest source
 
-	;ld      iy,Searchreplac**********mag weg*********************
+	;ld      iy,Searchreplac********may go*******************
 	ld	hl,Replacetext	;4740********************************
 _doreplace3:
 	ld	a,(hl)
@@ -6579,7 +6579,7 @@ _copydeel1:
 Replace:	defb	"Replace ? (y/n)",0
 Searchplaats:	defw	0
 
-;----- print tekst op commandline
+;----- print text on command line
 
 txttocomm:
 	push	hl
@@ -6602,14 +6602,14 @@ wiscommline:
 	xor	a
 	jp	fillvram
 
-;routines hoofdprogramma ###################################################
+;routines main program ###################################################
 
 ;----- Memory
 
 Textbufadres:	defw	0
 Slotp0adres:	defw	0
-Soortmem:	defb	0	;ACHTER ELKAAR
-Dosversion:	defb	0	;ACHTER ELKAAR
+Soortmem:	defb	0	;IN A ROW
+Dosversion:	defb	0	;IN A ROW
 Page0adres:	defw	0
 Compassadres:	defw	0
 Sp_memory:	defw	0
@@ -6617,7 +6617,7 @@ Sp_memory:	defw	0
 Memory_x:	defb	1
 Memory_y:	defb	1
 Memory_oldy:	defb	1
-Memory_chg:	defb	0	;0=normaal, 1=Compass-sloten
+Memory_chg:	defb	0	;0=normal, 1=Compass slot
 
 domemory:
 	ld	(Sp_memory),sp
@@ -6804,13 +6804,13 @@ memory_space:
 	add	hl,de
 	add	hl,de
 	ld	(Chgbuffer),hl
-	ld	(iy+3),2	;kenmerk: pages
+	ld	(iy+3),2	;feature: pages
 	jr	changehoofd
 
 mem_label:
 	ld	a,(iy+1)
 	sub	9
-	ld	(iy+1),a	;wordt later hersteld
+	ld	(iy+1),a	;will be restored later
 	jr	_mem_source1
 mem_data:
 	ld	a,(iy)
@@ -6840,7 +6840,7 @@ _mem_source2:
 	inc	hl
 	add	hl,de
 	ld	(Chgbuffer),hl
-	ld	(iy+3),0	;normale change
+	ld	(iy+3),0	;normal change
 	jr	_changehoof1
 
 mem_compass:
@@ -6854,7 +6854,7 @@ mem_compass:
 	ld	hl,(Compassadres)
 	add	hl,de
 	ld	(Chgbuffer),hl
-	ld	(iy+3),1	;Compass-sloten
+	ld	(iy+3),1	;Compass slot
 _changehoof1:
 	ld	a,(hl)
 	ld	(Oldvalue),a
@@ -6863,7 +6863,7 @@ _changehoof1:
 	ld	a,(hl)
 	ld	(Oldvalue+1),a
 	call	exist
-	res	6,(ix)	;ook goed bij einde 
+	res	6,(ix)	;also good at the end
 
 changehoofd:
 	call	getkey
@@ -6896,7 +6896,7 @@ changeback:
 	inc	hl
 	ld	a,(hl)
 	call	exist
-	set	6,(ix)	;ook goed bij einde
+	set	6,(ix)	;also good at the end
 	ld	a,(iy+3)
 	dec	a
 	jr	nz,_changeback1
@@ -6905,7 +6905,7 @@ changeback:
 	call	moveprog
 _changeback1:
 	ld	a,(iy+2)
-	ld	(iy+1),a	;herstel van label
+	ld	(iy+1),a	;recovery of label
 	jp	memory_hoofd
 
 changeright:
@@ -6991,7 +6991,7 @@ _prtsourceb1:
 	inc	de
 	call	prtmem
 	pop	hl
-	ld	bc,Textbuffer2-Textbuffer1	;KLOPT ! (OOK HIER)
+	ld	bc,Textbuffer2-Textbuffer1	;BEATS ! (ALSO HERE)
 	add	hl,bc
 	ex	de,hl
 	pop	hl
@@ -7003,7 +7003,7 @@ _prtsourceb1:
 
 printdatab:
 	ld	hl,(Textbufadres)
-	ld	de,Databuffer1-Textbuffer1	;KLOPT !
+	ld	de,Databuffer1-Textbuffer1	;BEATS !
 	add	hl,de
 	ex	de,hl
 	ld	hl,8*80+42
@@ -7018,7 +7018,7 @@ _prtdatab1:
 	inc	de
 	call	prtmem
 	pop	hl
-	ld	bc,Databuffer2-Databuffer1	;KLOPT
+	ld	bc,Databuffer2-Databuffer1	;BEATS
 	add	hl,bc
 	ex	de,hl
 	pop	hl
@@ -7030,7 +7030,7 @@ _prtdatab1:
 
 printlabb:
 	ld	hl,(Textbufadres)
-	ld	de,Labelbuffer-Textbuffer1	;KLOPT !
+	ld	de,Labelbuffer-Textbuffer1	;BEATS !
 	add	hl,de
 	ex	de,hl
 	ld	hl,17*80+42
@@ -7046,7 +7046,7 @@ printpages:
 	ld	bc,#0303
 	call	prtmem
 	inc	de	;***********************************
-	inc	de	;Page 3 staat 2 bytes verder
+	inc	de	;Page 3 is 2 bytes ahead
 	ld	bc,#0101
 	call	prtmem
 	ld	hl,17*80+76
@@ -7061,7 +7061,7 @@ _printpages1:
 	call	geefsoortblk
 	and	%10
 	ld	bc,3
-	call	z,fillvram	;wis aantal blokken
+	call	z,fillvram	;clear number of blocks
 	inc	de
 	inc	de
 	ld	bc,80
@@ -7146,9 +7146,9 @@ Mt6_1:	defb	"None  "
 Mt6_2:	defb	"Dos 2 "
 Mt6_3:	defb	"Memman"
 
-;----- Geef soort+aantal blokken bij bep. page+slot
+;----- Specify type+number of blocks at spec. page+slot
 ;----- IN:  A=slot, B=page
-;----- UIT: A=soort, B=aantal (0=geen mapper)
+;----- OUT: A=sort, B=number (0=no mapper)
 zoeksoort:
 	ld	a,(ix)
 	ld	b,d
@@ -7209,8 +7209,8 @@ inimem:
 	ld	(_freedos2_1+1),hl
 	ret
 
-;---------- Allocate al het beschikbare geheugen en zet in Buffer1024
-;---------- (Slot, blok, slot, ......., blok, 0)
+;---------- Allocate all available memory and put in Buffer1024
+;---------- (Slot, block, slot, ......., block, 0)
 
 allocatemem:
 	ld	a,(Soortmem)
@@ -7223,13 +7223,13 @@ alldos1:
 	ex	de,hl
 	ld	iy,#fcc1
 	ld	ix,(Bufferpage0)
-	ld	hl,500	;bijna 8 Mb
-	ld	bc,#1000	;b=aantal, c=slot
+	ld	hl,500	;almost 8 MB
+	ld	bc,#1000	;b=number, c=slot
 _alldos1_3:
 	push	bc
 	ld	a,(de)
 	or	a
-	jr	z,_alldos1_1	;rom of vast ram
+	jr	z,_alldos1_1	;rom or fixed ram
 	bit	7,(iy)
 	jr	z,_alldos1_4
 	set	7,c
@@ -7305,7 +7305,7 @@ allocate:
 	jr	nz,allocmemman
 allocdos2:
 	ld	a,(Primary)
-	or	%00110000	;eerst andere sloten, dan primary slot 
+	or	%00110000	;first other slots, then primary slot
 	ld	b,a
 	ld	a,1	;system segment  
 _allocdos2_1:
@@ -7327,8 +7327,8 @@ allocmemman:
 	ret
 
 
-;---------- Voegt gebruikte geheugen toe
-;----- IN:  IX = eindadres Buffer1024
+;---------- Add used memory
+;----- IN:  IX = end address Buffer1024
 
 addusedmem:
 	ld	hl,(Compassadres)
@@ -7372,7 +7372,7 @@ _addusedmem2:
 	ld	a,(Soortmem)
 	or	a
 	jr	nz,_addusedm2_1
-_addusedm2_2:	;AANROEPADRES !
+_addusedm2_2:	;CALLING ADDRESS !
 	push	bc
 	ld	b,(hl)
 	inc	hl
@@ -7402,7 +7402,7 @@ _addusedm2_1:
 	ld	(ix),0
 	ret
 
-;---------- Voegt TPAnrs uit de primary mapper toe (indien afwezig)
+;---------- Adds TPA nums from the primary mapper (if absent)
 
 addblok123:
 	ld	a,(#f344)
@@ -7414,8 +7414,8 @@ _addblok12_1:
 	ld	a,(hl)
 	ld	b,c
 	call	exist
-	set	4,(ix)	;markeren als tpa
-	jr	nc,_addblok12_2	;bestaat al
+	set	4,(ix)	;mark as tpa
+	jr	nc,_addblok12_2	;already exists
 	set	4,b
 	ld	(ix),b
 	inc	ix
@@ -7428,9 +7428,9 @@ _addblok12_2:
 	djnz	_addblok12_1
 	ret
 
-;---------- Test of blok aanwezig is
-;----- IN:  B = slot, A = blok
-;----- UIT: IX = laatste adres, [C] = bestaat niet
+;---------- Test whether block is present
+;----- IN:  B = lock, A = block
+;----- OUT: IX = last address, [C] = does not exist
 
 exist:
 	ld	c,a
@@ -7444,15 +7444,15 @@ _exist1:
 	or	a
 	scf
 	ret	z
-	and	%10001111	;bit 4 en 6 maskeren
+	and	%10001111	;mask bit 4 and 6
 	cp	b
 	jr	nz,_exist1
 	ld	a,(ix+1)
 	cp	c
 	jr	nz,_exist1
-	ret		;staat op [NC]
+	ret		;[NC] is set
 
-;---------- Geeft overige segmenten weer vrij
+;---------- Release other segments again
 
 freemem:
 	ld	a,(Soortmem)
@@ -7472,7 +7472,7 @@ _freemem1:
 	jr	nz,_freemem1
 	bit	6,a
 	jr	nz,_freemem3
-	and	%10001111	;voor zekerheid
+	and	%10001111	;to be sure
 	ld	b,a
 	ld	c,(ix+1)
 	call	free
@@ -7504,9 +7504,9 @@ freememman:
 	pop	ix
 	ret
 
-;---------- Zoek volgende/vorige blok
-;----- IN:  A: 0=vooruit, 1=achteruit
-;-----      IX: adres bron
+;---------- Find next/previous block
+;----- IN:  A: 0=forward, 1=backward
+;-----      IX: source address
 
 Changepage:	defb	0
 
@@ -7541,7 +7541,7 @@ _zoekpgacht2:
 	ld	a,11
 _zoekpgacht4:
 	add	a,c
-_zoekpgacht3:	;label overbodig??************************************
+_zoekpgacht3:	;label redundant??************************************
 	call	setsecundair
 	call	zoeksoort
 	ld	(ix+1),b
@@ -7574,7 +7574,7 @@ _zoekpgvoor2:
 	ld	a,-11
 _zoekpgvoor4:
 	add	a,c
-_zoekpgvoor3:	;label overbodig?*******************************************
+_zoekpgvoor3:	;label redundant?*******************************************
 	call	setsecundair
 	ld	(ix+1),0
 	call	zoeksoort
@@ -7603,7 +7603,7 @@ _zoeken5:
 	ld	c,a
 	ld	d,a	;0-0 0
 	or	a
-	jr	z,_zoeken1	;blok is leeg
+	jr	z,_zoeken1	;block is empty
 	and	%11
 	ld	b,a
 	ld	a,(ix)
@@ -7621,14 +7621,14 @@ _zoeken4:
 _zoeken3:
 	pop	ix
 	ld	(ix),b
-	ld	(ix+1),a	;nieuwe blok zetten
+	ld	(ix+1),a	;set a new block
 	ld	a,b
 	or	a
-	jr	nz,_zoeken2	;niet leeg
+	jr	nz,_zoeken2	;not empty
 	ld	a,(Magleeg)
 	or	a
 	ld	a,(Zoekrichting)
-	jr	z,_zoeken5	;mag niet leeg zijn
+	jr	z,_zoeken5	;cannot be empty
 
 _zoeken2	LD	A,(IY+#02)
 	CP	#0B
@@ -7646,7 +7646,7 @@ J78FF
 	cp	5
 	ret	nz
 	CALL	C7911
-	jr	nz,_zoeken5	;1e blok van labelb. => primary
+	jr	nz,_zoeken5	;1st block of labelb. => primary
 	ret
 
 C7911	ld	a,(#f344)
@@ -7663,7 +7663,7 @@ vooruit:
 	ld	ix,(Bufferpage0)
 	dec	ix
 	dec	ix
-	ld	h,#ff	;primair slot #ff
+	ld	h,#ff	;primary slot #ff
 _vooruit1:
 	inc	ix
 	inc	ix
@@ -7713,7 +7713,7 @@ _vooruit4:
 	xor	a
 	ld	b,a
 	inc	h
-	ret	z	;leeg
+	ret	z	;empty
 	ld	ix,(Foundadres)
 	ld	b,(ix)
 	res	4,b
@@ -7726,12 +7726,12 @@ achteruit:
 	ld	a,b
 	or	c
 	jr	nz,_achteruit5
-	ld	b,#ff	;primair slot #ff
+	ld	b,#ff	;primary slot #ff
 _achteruit5:
 	ld	ix,(Bufferpage0)
 	dec	ix
 	dec	ix
-	ld	hl,0	;slot 0-0 (KAN NIET !)
+	ld	hl,0	;lock 0-0 (CAN NOT !)
 _achteruit1:
 	inc	ix
 	inc	ix
@@ -7781,7 +7781,7 @@ _achteruit4:
 	ld	a,h
 	or	l
 	ld	b,a
-	ret	z	;leeg 
+	ret	z	;empty
 	ld	ix,(Foundadres)
 	ld	b,(ix)
 	res	4,b
@@ -7798,7 +7798,7 @@ parseregist:
 	ld	(Bufferpage0),hl
 	ld	a,(kbuf)
 	or	a
-	ret	z	;t'is een nieuwe compass, behoud default
+	ret	z	;it's a new compass, keep default
 	LD	hl,kbuf+#f4
 	LD	de,Inst1
 	LD	A,4
@@ -7825,7 +7825,7 @@ J7A35:	LD	A,(HL)
 	INC	HL
 	JR	J7A35
 
-;Variabelen
+;Variables
 
 Editor_y:	defb	2
 Editor_x:	defb	1
@@ -7939,21 +7939,21 @@ _wait:
 tweedelijn	db	0
 
 	defs	(256+64+10)-($-Zin),0
-Label:	equ	Zin+161	;30 tekens + 0   ;*******okee
-Commando:	equ	Label+31	;10 tekens + 0   ;?
-Register1:	equ	Commando+11	;146tekens + 0   ;?nergens gebruikt!***
-Register2:	equ	Register1+146	;80 tekens + 0   ;?
+Label:	equ	Zin+161	;30 characters + 0 ;*******okay
+Commando:	equ	Label+31	;10  characters + 0   ;?
+Register1:	equ	Commando+11	;146 characters + 0   ;?used nowhere!***
+Register2:	equ	Register1+146	;80 characters + 0   ;?
 
 einde2:
 
-;!!!!!!!!!!!!!!!!!!!!!!!!! Dubbel gebruikte variabelen/adressen
+;!!!!!!!!!!!!!!!!!!!!!!!!! Duplicate variables/addresses
 Doubleusepg1:
 	org	Doubleadres
 
 Doubleuse:
 Used_fcb:	defw	0
 Foutadres:	defw	0
-Veranderd:	defb	0	;0=regel niet veranderd, 1=wel
+Veranderd:	defb	0	;0=line not changed, 1=yes
 GOedit_ret1:
 	push	hl
 	ld	hl,edit_ret1
@@ -7987,12 +7987,12 @@ GOprinterror:
 	push	hl
 	ld	hl,printerrors
 	jp	gotoeditor
-Bufferpage0:	defw	0	;adres buffer in page 0
+Bufferpage0:	defw	0	;address buffer in page 0
 Labbloknr:	defb	0	;(1-..)
-Idhex:	defb	"#",0,0	;"# " voor (laatste 1=na)   KOPIE
-Idbin:	defb	"%",0,0	;"% " voor (Laatste 1=na)   KOPIE
+Idhex:	defb	"#",0,0	;"# " before (last 1=after)   COPY
+Idbin:	defb	"%",0,0	;"% " before (Last 1=after)   COPY
 Huidiglablen:	defb	12
-Binheader:	defw	0	;adres header bin-files
+Binheader:	defw	0	;address header bin-files
 GOtxttocomm:
 	push	hl
 	ld	hl,txttocomm
@@ -8015,7 +8015,7 @@ GOeditscreen:
 	ld	hl,editscreen
 	jp	gotoeditor
 Aantaltextbl:	defb	8
-Textbuffers:	defb	#83,9,#83,10,#83,11,#83,12	;waarom al ingevuld?***
+Textbuffers:	defb	#83,9,#83,10,#83,11,#83,12	;why already filled in?***
 	defb	#83,13,#83,14,#83,15,#83,16
 	defb	0,0,0,0,0,0,0,0
 	defb	0,0,0,0,0,0,0,0
@@ -8040,8 +8040,8 @@ GOsetbuf:
 	push	hl
 	ld	hl,setnewbuffer
 	jp	gotoeditor
-Textbuffer:	defb	startbuf	;huidige textbuffer
+Textbuffer:	defb	startbuf	;current text buffer
 Doubleuseend:
 
-	ds	#8000-Doubleusepg1-($-Doubleadres),0	;opvul tot einde
+	ds	#8000-Doubleusepg1-($-Doubleadres),0	;fill to the end
 

--- a/Compass129Sources/DATfile/MAIN129.ASC
+++ b/Compass129Sources/DATfile/MAIN129.ASC
@@ -1,4 +1,4 @@
-;HOOFDPROGRAMMA COMPASS #1.2.09
+;MAIN PROGRAM COMPASS #1.2.09
 ;JDS 08/09/99
 ;ctng-protection built in
 ;#1.2.09: DOINCLUDE SEPARATE FCB
@@ -9,34 +9,34 @@ cursory_x	equ	#f3dc
 trgflg	equ	#f3e8
 msxtype	equ	#002d
 stopvlag	equ	#fc9b
-cursoronoff	equ	#fca9	;0=niet tonen
+cursoronoff	equ	#fca9	;0=don't show
 insonoff	equ	#fcaa	;1=inscursor
 kbuf	equ	#f41f
-queuebc	equ	#f9f5	;256 bytes ruimte in geluidsqueue b en c
+queuebc	equ	#f9f5	;256 bytes of space in sound queue b and c
 hookadres	equ	queuebc
 matrix	equ	#fbe5
 ctngcode	equ	#ff79
 
-videoramfree	equ	#1a00	;vanaf hier is videoram vrij voor gebruik
+videoramfree	equ	#1a00	;from here videoram is free to use
 Dskerrline	equ	14
-Testlabeladr	equ	#400c	;in ass/monitorsegment
-MAININSTPROG	equ	#4009	;in debuggersegment
-SETDEBPARS	equ	#400c	;in debuggersegment
+Testlabeladr	equ	#400c	;in ass/monitor segment
+MAININSTPROG	equ	#4009	;in debugger segment
+SETDEBPARS	equ	#400c	;in debugger segment
 ;--------------------------------------------
 	ORG	#0140
 
 	JR	shellentry
 	JP	#8000+set_slot_p0
-	db	1,2	;versiecode (Spanje:2,2)
+	db	1,2	;version code (Spain:2,2)
 	dw	codename	;codename
 	JP	#8000+startcompass
 shellentry	DI
 	LD	(sp_back_2_dos),SP
 	ld	hl,ctngcode
 	res	0,(hl)
-	IN	A,(#A8)	;komen we uit basic of uit dos?
-	AND	#0C	;basic: page1 staat dan in slot 0
-	ld	c,a	;verdere controle op slot 0.1/2/3
+	IN	A,(#A8)	;do we come from basic or from dos?
+	AND	#0C	;basic: page1 is then in slot 0
+	ld	c,a	;further check on slot 0.1/2/3
 	ld	a,(#fcc1)
 	rlca
 	ld	a,c
@@ -44,9 +44,9 @@ shellentry	DI
 	ld	a,(#fcc5)
 	and	#0c
 	or	c
-not_expanded	LD	(dosbasic),A	;bewaar result: 0=basic not0=dos
+not_expanded	LD	(dosbasic),A	;save result: 0=basic not0=dos
 
-	LD	HL,#FFFF	;op alle pages: schakel echt het slot
+	LD	HL,#FFFF	;on all pages: really switch the slot
 	LD	(oudslot),HL
 	LD	(oudslot+2),HL
 
@@ -63,14 +63,14 @@ noteerstekeer	CALL	clearhooks
 	CALL	inidos
 	LD	A,(keer1e)
 	OR	A
-	CALL	NZ,fill_NAMEASM	;zet NAME.ASM in 4 sbuffers
+	CALL	NZ,fill_NAMEASM	;put NAME.ASM in 4 sbuffers
 	XOR	A
 	LD	(keer1e),A
 	CALL	SCREENCOMPASS
 	LD	A,(oldprog)
 	OR	A
 	JR	NZ,_gotonextprog
-	LD	HL,videoramfree	;haal asmnaam uit vram en zet in kbuf
+	LD	HL,videoramfree	;extract asmname from vram and put in kbuf
 	LD	DE,kbuf
 	LD	A,(comline_nr)
 	INC	A
@@ -90,7 +90,7 @@ _startprogr1	LD	(oldprog),A
 	PUSH	DE
 	CALL	zetslot
 	LD	BC,#0101
-	CALL	OFFSET	;ivm muis
+	CALL	OFFSET	;about mouse
 	LD	IX,buffer1024
 	POP	HL
 	LD	DE,tab_memtabel
@@ -100,7 +100,7 @@ calladdress	dw	0
 	PUSH	AF
 	XOR	A
 	LD	(comline_nr),A
-	CALL	setscreen1	;wis scherm+txt_menu
+	CALL	setscreen1	;clear screen+txt_menu
 	POP	AF
 	CP	#04
 	JP	Z,goshell
@@ -111,10 +111,10 @@ _gotonextprog	DEC	A
 	DEC	A
 	JR	Z,startdebugger	;2
 	JR	startmonitor
-oldprog	db	0	;moet nul: start assembler 1e keer
+oldprog	db	0	;must be zero: start assembler 1st time
 
-startdebugger	db	#1e	;beter: ld e,n
-debuggerreg	db	0	;speciale info voor debugger
+startdebugger	db	#1e	;better: ld e,n
+debuggerreg	db	0	;special info for debugger
 	LD	HL,#4000
 	LD	BC,(slotdebugger)
 	LD	A,#02
@@ -123,11 +123,11 @@ startmonitor	LD	HL,#7000
 	LD	BC,(slotmonitor)
 	LD	A,#03
 	jr	_startprogr
-setscreen1	LD	HL,#181E	;blink off regel 3-26, 0,1,2niet
+setscreen1	LD	HL,#181E	;blink off line 3-26, 0,1,2not
 	LD	BC,24*10
 	XOR	A
 	CALL	FILLVRAM
-	LD	HL,#0000	;leeg scherm (volledig,ook bovenmenu)
+	LD	HL,#0000	;empty screen (full, also top menu)
 	LD	BC,27*80
 	XOR	A
 	CALL	FILLVRAM
@@ -136,10 +136,10 @@ setscreen1	LD	HL,#181E	;blink off regel 3-26, 0,1,2niet
 quitvlag	db	0
 quitcompass	LD	BC,(sloteditor)
 	CALL	zetslot
-	CALL	#401B	;vrijgeven geheugen
+	CALL	#401B	;release memory
 	ld	hl,(#f349)
 	db	#11	;LD DE,nn
-newf349	dw	0	;onder dos2 blijft dit 0
+newf349	dw	0	;under dos2 this remains 0
 	ld	a,h
 	cp	d
 	jr	nz,alleslaten
@@ -149,16 +149,16 @@ newf349	dw	0	;onder dos2 blijft dit 0
 	db	#21	;LD HL,nn
 oldf349	dw	0
 	ld	(#f349),hl
-alleslaten	XOR	A	;wis compassID
+alleslaten	XOR	A	;clear compassID
 	LD	(queuebc+4),A
-	LD	A,(dosversion)	;wis envitem compass onder dos2
+	LD	A,(dosversion)	;delete envitem compass under dos2
 	CP	#02
 	JR	C,nietdos2
-	XOR	A	;vervang spatie door punt
+	XOR	A	;replace space with period
 	LD	(compasscom+7),A
 	LD	HL,compasscom	;name
 	LD	DE,queuebc+4	;value =0
-	LD	C,#6C	;set envitem, nu dus remove
+	LD	C,#6C	;set envitem, now remove
 	CALL	bdos
 nietdos2	LD	A,#01
 	LD	(quitvlag),A
@@ -166,8 +166,8 @@ goshell	LD	A,(insonoff)
 	LD	(stat_ins),A
 	XOR	A
 	LD	(cursoronoff),A
-	LD	(stopvlag),A	;wis de "STOPkey-buffer"
-	LD	(insonoff),A	;blokcursor
+	LD	(stopvlag),A	;clear the "STOPkey buffer"
+	LD	(insonoff),A	;block cursor
 	LD	IX,#005F	;screen 0
 	CALL	gobios
 	LD	A,(#F343)
@@ -200,10 +200,10 @@ uitbasic	LD	SP,(sp_back_2_dos)
 	set	0,(hl)
 	JP	hook_back-hook+hookadres
 dostekst	db	"_SYSTEM",13
-stat_ins	db	1	;insstatus 0=blokcursor 1=streepcursor
-sp_back_2_dos	dw	0	;backup dos-stackpointer
-keer1e	db	1	;staat na laden C op 1 (test op filenaam)
-dosbasic	db	0	;vlag om te zien of je uit basic komt
+stat_ins	db	1	;insstatus 0=block cursor 1=stripe cursor
+sp_back_2_dos	dw	0	;backup dos stack pointer
+keer1e	db	1	;after loading C is set to 1 (test on filename)
+dosbasic	db	0	;flag to see if you are from basic
 
 sethooks	CALL	gethookadres
 	LDIR
@@ -235,26 +235,26 @@ clearhooks	CALL	gethookadres
 	RET
 data_2_editor	CALL	getreg
 	EXX
-	LD	HL,buffer1024	;werkgebied voor uitpakken codename
+	LD	HL,buffer1024	;work area for unpacking codename
 	EXX
 	PUSH	HL
-	LD	HL,#400F	;parse registers to editor(bij 1e keer)
+	LD	HL,#400F	;parse registers to editor(at 1st time)
 	JP	GOTOEDITOR
-fill_NAMEASM	LD	HL,pathnamebuf	;gebruik max. 64 bytes uit de
+fill_NAMEASM	LD	HL,pathnamebuf	;use max. 64 bytes from the
 	LD	DE,pathname	;pathnamebuffer
 	LD	BC,64
 	LDIR
 	LD	B,#04
 nxt_name_deb	PUSH	BC
-	XOR	A	;laad 4 filenames+path in debugger
-	CALL	parse_nam_deb	;deze routine zit toevallig in het
-	POP	BC	;debuggersegment
+	XOR	A	;load 4 filenames+path in debugger
+	CALL	parse_nam_deb	;this routine happens to be in the
+	POP	BC	;debugger segment
 	DJNZ	nxt_name_deb
 	RET
 
-chk_comline	LD	A,(#0080)	;staat er nog iets op de commandline?
+chk_comline	LD	A,(#0080)	;is there anything else on the command line?
 	OR	A
-	RET	Z	;nee
+	RET	Z	;new
 	LD	(comline_nr),A
 	LD	HL,videoramfree
 	CALL	SETVRAMWRITE
@@ -262,12 +262,12 @@ chk_comline	LD	A,(#0080)	;staat er nog iets op de commandline?
 _chk_comline	LD	A,(HL)
 	INC	HL
 	CP	#20
-	JR	Z,_chk_comline	;spaties worden genegeerd
-	OUT	(#98),A	;de rest gaat naar het vram, inclusief
-	OR	A	;de nulbyte
+	JR	Z,_chk_comline	;spaces are ignored
+	OUT	(#98),A	;the rest goes to the vram, including
+	OR	A	;the zero byte
 	RET	Z
 	JR	_chk_comline
-comline_nr	db	0	;MOET op nul
+comline_nr	db	0	;MUST be zero
 
 SCREENCOMPASS	LD	A,80	;width 80
 	LD	(#F3AE),A
@@ -285,16 +285,16 @@ SCREENCOMPASS	LD	A,80	;width 80
 	LD	IX,#00CC	;key off
 	CALL	gobios
 	CALL	setcolors
-	XOR	A	;keyclick uit
+	XOR	A	;key click off
 	LD	(#F3DB),A
-	INC	A	;cursor niet zichtbaar
+	INC	A	;cursor not visible
 	LD	(#FCA9),A
 	CALL	WISBLINKTABEL
 	CALL	SETCOLOR1
 	DI
-	LD	A,(#F3E2)	;bewaar vdp3
+	LD	A,(#F3E2)	;save vdp3
 	LD	(oldblink),A
-	LD	A,%01100111	;blinktabel op #1800
+	LD	A,%01100111	;blink table at #1800
 	LD	(#F3E2),A
 	OUT	(#99),A
 	LD	A,#83
@@ -305,18 +305,18 @@ SCREENCOMPASS	LD	A,80	;width 80
 	OUT	(#99),A
 	LD	A,#89
 	OUT	(#99),A
-	LD	A,#10	;1/5sec aan en 0sec uit:=constant aan
+	LD	A,#10	;1/5sec on and 0sec off:=constantly on
 	OUT	(#99),A
 	LD	A,#8D
 	OUT	(#99),A
 	CALL	CLS
-	LD	HL,#1800	;3 bovenste lijnen gekleurd
+	LD	HL,#1800	;3 top lines colored
 	LD	BC,3*10
 	LD	A,#FF
 	CALL	FILLVRAM
 	LD	HL,txt_bovenaan
 	CALL	TEXTTOBLOK
-	LD	HL,vormen	;verander karakter 17-29
+	LD	HL,vormen	;change character 17-29
 	LD	DE,#1000+17*8
 	LD	BC,13*8
 	JP	RAMTOVRAM
@@ -329,7 +329,7 @@ setcolors	DI
 	LD	BC,#209A
 	OTIR
 	RET
-txt_bovenaan	dw	1	;vramadres
+txt_bovenaan	dw	1	;vramaddress
 	db	"Compass #1.2",0
 	dw	55
 	db	"1998 by Compjoetania TNG",0
@@ -343,9 +343,9 @@ color	db	#00,0,#00,0,#77,7,#04,0,#17,1,#27,3,#51,1,#27,6
 OLDSCREEN	CALL	WISBLINKTABEL
 	CALL	CLS
 	LD	A,#01
-	LD	(cursoronoff),A	;cursor uit
+	LD	(cursoronoff),A	;cursor off
 	DI
-	LD	A,(oldblink)	;herstel vdp 3
+	LD	A,(oldblink)	;restore vdp 3
 	LD	(#F3E2),A
 	OUT	(#99),A
 	LD	A,#83
@@ -356,15 +356,15 @@ OLDSCREEN	CALL	WISBLINKTABEL
 	OUT	(#99),A
 	LD	A,#89
 	OUT	(#99),A
-	XOR	A	;blinkperiod 00
+	XOR	A	;blink period 00
 	OUT	(#99),A
 	LD	A,#8D
 	OUT	(#99),A
-	LD	A,(oldfunkkey)	;herstel ev. functietoetsen
+	LD	A,(oldfunkkey)	;restore any function keys
 	LD	(#F3DE),A
 	LD	IX,#00C9
 	CALL	gobios
-	XOR	A	;screen nul
+	XOR	A	;screen zero
 	LD	IX,#005F
 	JP	gobios
 
@@ -372,11 +372,11 @@ oldblink	db	0
 oldfunkkey	db	0
 
 
-inidos	LD	C,#18	;get login vector: haal connected drives
+inidos	LD	C,#18	;get login vector: get connected drives
 	CALL	bdos
 	LD	A,L
 	LD	(drives),A
-	LD	A,#03	;begin op 'DIR'
+	LD	A,#03	;start on 'DIR'
 	LD	(Diskmenu),A
 
 	LD	(diskhook_sp),SP
@@ -387,14 +387,14 @@ inidos	LD	C,#18	;get login vector: haal connected drives
 clrdiskhooks	LD	HL,(olderroradres)
 	LD	(#F323),HL
 	LD	A,#C9	;insert disk for drive...
-	LD	(#F24F),A	;weer normaal
+	LD	(#F24F),A	;back to normal
 	RET
 setdiskhooks	LD	HL,(#F323)
 	LD	(olderroradres),HL
 	LD	HL,diskhook1
 	LD	(#F323),HL
 	LD	HL,#C9F1	;pop af,ret
-	LD	(#F24F),HL	;ter ondervanging: insert disk...
+	LD	(#F24F),HL	;to replace: insert disk...
 	RET
 diskhook1	dw	dodiskhook
 dodiskhook	db	#31	;ld sp,nn
@@ -422,13 +422,13 @@ haalpath	LD	C,#19	;get default drive
 	LD	A,(dosversion)
 	DEC	A
 	RET	Z
-	LD	BC,#0059	;doe enkel voor dos2
+	LD	BC,#0059	;only do for dos2
 	LD	DE,pathnamebuf+3
 	PUSH	DE
 	CALL	bdos
 	POP	HL
-	LD	A,(HL)	;rootdirectory?
-	OR	A	;ja, pathname is dan al goed
+	LD	A,(HL)	;root directory?
+	OR	A	;yes, pathname is already good
 	RET	Z
 	LD	HL,pathnamebuf
 	LD	BC,64
@@ -439,10 +439,10 @@ haalpath	LD	C,#19	;get default drive
 	LD	(HL),"\"
 	INC	HL
 	RET
-dosversion	db	0	;dos 1 of 2
+dosversion	db	0	;dos 1 or 2
 drives	db	0	;login vector
-huidigedrive	db	0	;defaultdrive
-pathname	db	" :\"	;huidige defaultdirectory
+huidigedrive	db	0	;default drive
+pathname	db	" :\"	;current default directory
 	ds	61,0
 pathnamebuf	ds	93,0
 
@@ -451,20 +451,20 @@ name_asm	db	"NAME    ASM"
 name_bin	db	"NAME    BIN"
 name_asc	db	"NAME    ASC"
 name_blk	db	"NAME    BLK"
-name_com1	db	"NAME    COM"	;waarschijnlijk voor dat en ass.to disk
+name_com1	db	"NAME    COM"	;probably for that and ass.to disk
 name_com2	db	"NAME    COM"
 name_tsr	db	"NAME    TSR"
 name_rel	db	"NAME    REL"
 
 stat_mem	db	0
-tab_ROMRAM	ds	#60,0	;ROMRAMtabel, 3*16*2=#60 bytes
+tab_ROMRAM	ds	#60,0	;ROMRAMtable, 3*16*2=#60 bytes
 tab_memory
 page0	db	0,0
 page1	db	0,0
 page2	db	0,0
-page3deb	db	0,0	;ivm debugger, zo laten
+page3deb	db	0,0	;i.e. debugger, leave it
 page3	db	0,0
-tab_compass	ds	8,0	;compassblocks, 8 bytes
+tab_compass	ds	8,0	;compass blocks, 8 bytes
 sloteditor	equ	tab_compass+0	;ok
 slothoofdp	equ	tab_compass+2	;ok
 slotass	equ	tab_compass+4	;ok
@@ -481,9 +481,9 @@ slotregister	PUSH	BC
 	POP	BC
 	RET
 
-;eigen routine (in page 2) die slot A inschakelt op page 0
-;ongewijzigd: IX,IY,spiegelregisters
-;dit vervangt de slotpage2 routine
+;own routine (in page 2) that turns on slot A on page 0
+;unchanged: IX,IY,mirror registers
+;this replaces the slotpage2 routine
 set_slot_p0	push	af
 	ld	a,#ff
 	ld	(#8000+oudslot),a
@@ -491,9 +491,9 @@ set_slot_p0	push	af
 	ld	b,a
 	bit	7,a
 	jr	nz,set_exp	;expanded slot?
-	IN	A,(#A8)	;nee, gewoon zetten
+	IN	A,(#A8)	;no, just put it
 	AND	#fc
-	OR	B	;merk op:bit 2-6 zijn 0 voor notexp.slot
+	OR	B	;note: bits 2-6 are 0 for notexp.slot
 	OUT	(#A8),A
 	RET
 set_exp	rrca
@@ -502,7 +502,7 @@ set_exp	rrca
 	and	#c0
 	ld	h,a
 	in	a,(#a8)
-	ld	e,a	;oude a8-stand bewaren in e
+	ld	e,a	;save old a8 status in e
 	and	#3f
 	or	h
 	out	(#a8),a
@@ -514,9 +514,9 @@ set_exp	rrca
 	and	#fc
 	or	l
 	ld	(#ffff),a
-	ld	d,a	;nieuwe ffff-stand in d
+	ld	d,a	;new ffff stand in d
 	ld	a,e
-	out	(#a8),a	;page 3 herstellen
+	out	(#a8),a	;page 3 restore
 	ld	hl,#fcc5
 	ld	a,b
 	and	#03
@@ -579,14 +579,14 @@ RAMTOVRAM	EX	DE,HL
 	CALL	SETVRAMWRITE
 	LD	A,B
 	OR	A
-	JR	Z,_ramtovram1	;snellere 8 bitscounter
+	JR	Z,_ramtovram1	;faster 8 bit counter
 _ramtovram3	LD	A,(DE)
 	INC	DE
 	OUT	(#98),A
 	DEC	BC
 	LD	A,B
 	OR	C
-	jp	NZ,_ramtovram3	;snelle jmp
+	jp	NZ,_ramtovram3	;fast jmp
 	RET
 _ramtovram1	LD	B,C
 _ramtovram2	LD	A,(DE)
@@ -607,7 +607,7 @@ _fillvram3	LD	A,H
 	DEC	BC
 	LD	A,B
 	OR	C
-	jp	nz,_fillvram3	;snelle jump
+	jp	nz,_fillvram3	;quick jump
 	ex	af,af'
 	ld	h,a
 	RET
@@ -641,16 +641,16 @@ SETCOLOR1	LD	A,(kleur1)
 kleur1	db	#23
 	;kleur2 db #45
 
-;----- Print decimaal getal  IN: HL=vramadres, DE=getal, B=aantal tekens
-;----- Opmerking: HL: bit15=1 => geen vramadres, B:bit7=1:geen voorloopnullen
-;----- Verandert: AF, BC, DE, HL
+;----- Print decimal number  IN: HL=vramaddress, DE=number, B=number of characters
+;----- Note: HL: bit15=1 => no vram address, B:bit7=1:no leading zeros
+;----- Changes: AF, BC, DE, HL
 PRINTDECIMAAL	call	SETVRAMWRITE
 	push	bc
 	ld	hl,0
 	ld	(Decimaal),hl
 	ld	(Decimaal+2),hl
 	ld	(Decimaal+3),hl
-	ex	de,hl	;hl=getal
+	ex	de,hl	;hl=number
 	ld	de,Decimaal+5
 	ld	c,#f6
 getdig:	xor	a
@@ -681,7 +681,7 @@ _dec_cont	ld	e,b
 	sbc	hl,de
 _nextdec:	ld	a,(hl)
 	or	c
-	jr	z,_nextdec1	;geen getal + geen voorloopnullen
+	jr	z,_nextdec1	;no number + no leading zeros
 	ld	a,(hl)
 	out	(#98),a
 _nextdec1:	inc	hl
@@ -689,14 +689,14 @@ _nextdec1:	inc	hl
 	ret
 Decimaal:	defb	0,0,0,0,0
 
-;----- Print hexadecimaal getal  IN: HL=vramadres, DE=getal, B=aantal tekens
-;----- Opmerking: HL:bit15=1 => geen vramadres, B:bit7=1 => geen id
-;----- Verandert: AF, BC, DE, HL
+;----- Print hexadecimal number  IN: HL=vramaddress, DE=number, B=number of characters
+;----- Note: HL:bit15=1 => no vram address, B:bit7=1 => no id
+;----- Changes: AF, BC, DE, HL
 PRINTHEXADECI	call	SETVRAMWRITE
 	ld	hl,0
 	ld	(Decimaal),hl
 	ld	(Decimaal+2),hl
-	ex	de,hl	;hl=getal
+	ex	de,hl	;hl=number
 	ld	de,Decimaal
 
 	bit	7,b
@@ -739,11 +739,11 @@ _printhexad2:
 _printhexad3:	ld	(de),a
 	inc	de
 	ret
-;----- Print binair getal  IN: HL=vramadres, DE=getal, B=aantal tekens
-;----- Opmerking: HL:bit15=1 => geen vramadres, B:bit7=1 => geen id
-;----- Verandert: AF, BC, DE, HL
+;----- Print binary number  IN: HL=vramaddress, DE=number, B=number of characters
+;----- Note: HL:bit15=1 => no vram address, B:bit7=1 => no id
+;----- Changes: AF, BC, DE, HL
 PRINTBINAIR:	call	SETVRAMWRITE
-	ex	de,hl	;hl=getal
+	ex	de,hl	;hl=number
 	bit	7,b
 ;      push  af
 	call	z,prtidbinvoor
@@ -754,9 +754,9 @@ PRINTBINAIR:	call	SETVRAMWRITE
 _printbinai2:	ld	d,0
 	sla	l
 	rl	h
-	rl	d	;d bevat de te printen bit (0 of 1)
+	rl	d	;d contains the bit to be printed (0 or 1)
 	ld	a,e
-	cp	c	;mag er al geprint worden?
+	cp	c	;can it be printed already?
 	jr	c,_printbinai1
 	ld	a,"0"
 	add	a,d
@@ -767,7 +767,7 @@ _printbinai1:	dec	c
 ;      call  z,prtidbinna
 	ret
 
-;balkroutines
+;bar routines
 setbalk1:	ex	de,hl
 	ld	c,b
 	ld	hl,#1800-10
@@ -807,16 +807,16 @@ wisbalk4:
 	call	READVRAM
 	jr	wisbalk6
 
-;----- zet balk op scherm: IN: b=lengte, (h,l)=doel
-SETBALK	call	setbalk1	;bereken offset
+;----- put bar on screen: IN: b=length, (h,l)=target
+SETBALK	call	setbalk1	;calculate offset
 setbalk5:	or	d
 	rrc	d
 	jr	c,setbalk4
 setbalk6:	djnz	setbalk5
 	jr	WRITEVRAM
 
-;----- wis balk van scherm: IN: b=lengte, (h,l)=doel
-WISBALK	call	setbalk1	;bereken offset
+;----- clear bar from screen: IN: b=length, (h,l)=target
+WISBALK	call	setbalk1	;calculate offset
 	ex	af,af'
 	ld	a,d
 	cpl
@@ -833,18 +833,18 @@ WRITEVRAM	ex	af,af'
 	out	(#98),a
 	ret
 
-; Kopieer: van Buffer-->bep. slot+blok
-; ----- IN: DE=Adres doel (page 0-3), BC=Lengte
+; Copy: from Buffer-->bep. lock+block
+; ----- IN: DE=Target address (page 0-3), BC=Length
 PUTTORAM	ex	de,hl
-	ld	a,1	;naar
+	ld	a,1	;nasty
 	jr	_getfromram1
 
 Broncopy:	defw	0
 Doelcopy:	defw	0
 Lengtecopy:	defw	0
-Command:	defb	0	;0=van geheugen, 1=naar geheugen
-; Kopieer: van bep. slot+blok-->Buffer
-; ----- IN: HL=Adres bron (page 0-3), BC=Lengte
+Command:	defb	0	;0=from memory, 1=to memory
+; Copy: from bep. slot+block-->Buffer
+; ----- IN: HL=Source address (page 0-3), BC=Length
 GETFROMRAM:	xor	a
 _getfromram1	ld	de,buffer1024
 	di
@@ -862,11 +862,11 @@ _getfromram1	ld	de,buffer1024
 	jr	_getfrompg3
 _getfrompg0:	push	hl
 	add	hl,bc
-	dec	hl	;HL=Laatste adres
+	dec	hl	;HL=Last address
 	ld	a,h
 	pop	hl
 	cp	#40
-	jp	c,_haalpage0	;Alles in page 0
+	jp	c,_haalpage0	;Everything in page 0
 	ld	ix,#4000
 	ld	(Bron2),ix
 	ld	ix,_haalpage0
@@ -874,11 +874,11 @@ _getfrompg0:	push	hl
 	jp	twopages
 _getfrompg1:	push	hl
 	add	hl,bc
-	dec	hl	;HL=Laatste adres
+	dec	hl	;HL=Last address
 	ld	a,h
 	pop	hl
 	cp	#80
-	jp	c,_haalpage1	;Alles in page 1
+	jp	c,_haalpage1	;Everything in page 1
 	ld	ix,#8000
 	ld	(Bron2),ix
 	ld	ix,_haalpage1
@@ -886,11 +886,11 @@ _getfrompg1:	push	hl
 	jp	twopages
 _getfrompg2:	push	hl
 	add	hl,bc
-	dec	hl	;HL=Laatste adres
+	dec	hl	;HL=Last address
 	ld	a,h
 	pop	hl
 	cp	#c0
-	jp	c,_haalpage2	;Alles in page 2
+	jp	c,_haalpage2	;Everything in page 2
 	ld	ix,#c000
 	ld	(Bron2),ix
 	ld	ix,_haalpage2
@@ -898,39 +898,39 @@ _getfrompg2:	push	hl
 	jp	twopages
 _getfrompg3:	push	hl
 	add	hl,bc
-	dec	hl	;HL=Laatste adres
+	dec	hl	;HL=Last address
 	ld	a,h
 	pop	hl
 	cp	#40
-	jp	nc,_haalpage3	;Alles in page 3
+	jp	nc,_haalpage3	;Everything in page 3
 	ld	ix,#0000
 	ld	(Bron2),ix
 	ld	ix,_haalpage3
 	ld	iy,_haalpage0
 twopages	ld	(_call1+1),ix
-	ld	(_call2+1),iy	;2 call adressen
-	ex	de,hl	;de=bron
+	ld	(_call2+1),iy	;2 call addresses
+	ex	de,hl	;de=source
 	ld	hl,(Bron2)
 	or	a
-	sbc	hl,de	;hl=lengte in 1e page
+	sbc	hl,de	;hl=length in 1st page
 	ld	b,h
-	ld	c,l	;bc=lengte
-	ex	de,hl	;hl=bron
+	ld	c,l	;bc=length
+	ex	de,hl	;hl=source
 	ld	de,(Doelcopy)
 	push	bc
 	push	de
-_call1:	call	0	;kopieer 1e deel
+_call1:	call	0	;copy 1st part
 	pop	hl
 	pop	bc
 	add	hl,bc
-	ex	de,hl	;de=adres doel
+	ex	de,hl	;de=address target
 	ld	hl,(Lengtecopy)
 	or	a
 	sbc	hl,bc
 	ld	b,h
-	ld	c,l	;bc=2e lengte
+	ld	c,l	;bc=2nd length
 	ld	hl,(Bron2)
-_call2:	jp	0	;kopieer 2e deel
+_call2:	jp	0	;copy 2nd part
 Bron2:	defw	0
 _haalpage1	push	hl
 	ld	a,(page1)
@@ -977,16 +977,16 @@ _haalpage0	push	hl
 	ld	h,#80
 	call	SLOT
 	ld	a,(slothoofdp+1)
-	call	SETPAGE2_DOS2	;Hoofdprogramma op page 2
+	call	SETPAGE2_DOS2	;Main program on page 2
 	jp	_haalpage0_1+#8000
 _haalpage0_1:	ld	a,(page0+#8000)
 	call	set_slot_p0+#8000
 	ld	a,(page0+1+#8000)
-	out	(#fc),a	;bronpage op page 0
-	pop	bc	;niet f2c7 of zo aanpassen, schakelen
-	pop	de	;van page0 is maar voorlopig
+	out	(#fc),a	;source page on page 0
+	pop	bc	;don't adjust f2c7 or anything, switch
+	pop	de	;from page0 is only provisional
 	pop	hl
-	set	7,d	;nu in page 2
+	set	7,d	;now on page 2
 	ld	a,(Command+#8000)
 	or	a
 	jr	z,_haalpage0_2
@@ -995,10 +995,10 @@ _haalpage0_2:	ldir
 	ld	a,(slothoofdp+#8000)
 	call	set_slot_p0+#8000
 	ld	a,(slothoofdp+1+#8000)
-	out	(#fc),a	;dit programma weer op page 0
+	out	(#fc),a	;this program back on page 0
 	ld	a,(#f343)
 	ld	h,#80
-	jp	SLOT	;automatisch naar page 0 terug
+	jp	SLOT	;automatically return to page 0
 
 DOINCLUDE	LD	(diskhook_sp),SP
 	PUSH	HL
@@ -1031,13 +1031,13 @@ DOINCLUDE	LD	(diskhook_sp),SP
 	LD	BC,(sloteditor)
 	CALL	zetslot
 	LD	DE,fcb_work
-	CALL	#4012	;laden
+	CALL	#4012	;load
 	PUSH	AF
 	CALL	CLOSEFILE
 	POP	AF
 _incl_error	PUSH	AF
 	CALL	clrdiskhooks
-	ld	hl,fcb_inclbkup	;herstel fcb_work
+	ld	hl,fcb_inclbkup	;restore fcb_work
 	ld	de,fcb_work
 	ld	bc,37
 	ldir
@@ -1053,22 +1053,22 @@ _incl_error	PUSH	AF
 ; Diskdrive: IN: A: 1 = assembler
 ;                   2 = debugger
 ;                   3 = monitor
-;                B = speciale optie: 1 = Asm disk, 2=TSR, 3=rel
-;                C = sourcebuffer, alleen bij Assembler
-;                IX = pointer naar jp-lijst (alleen bij Assembler)
-;             UIT: [C] = er is geformatteerd (Alleen voor Assembler belangrijk)
+;                B = special option: 1 = Asm disk, 2=TSR, 3=rel
+;                C = source buffer, only with Assembler
+;                IX = pointer to jp list (Assembler only)
+;             OOUT: [C] = it has been formatted (Important for Assembler only)
 Soort:	defb	1	;1=asm, 2=asc, 3=bin, 4=dat, 5=blk, 6=sect
-Diskasm:	defb	0	;ietsmetassembleren?0nee,1disk,2TSR,3rel
+Diskasm:	defb	0	;something to assemble?0no,1disk,2TSR,3rel
 Bronprog:	defb	0
 Buffer:	defb	0
 Backuponoff:	defb	0	;0=off
 Oldsubrouti:	defw	0
 Pointer:	defw	0
-Diskmenu:	defb	3	;beginnen op 'dir'
+Diskmenu:	defb	3	;start on 'dir'
 Driveletter:	defb	0
 Aantalfiles:	defb	0
 Asmbusy:	defb	0
-adrsfilepath	dw	0	;beginadres filenaam in path
+adrsfilepath	dw	0	;start address filename in path
 fcb_work	db	0,"???????????"
 	ds	25
 	NOP		;0C7A
@@ -1096,13 +1096,13 @@ GODISKDRIVE	di
 	ld	hl,Specialerror
 	ld	(#f323),hl
 	ld	hl,#c9f1	;pop af, ret
-	ld	(#f24f),hl	;ondervanging "Insert disk ..."
+	ld	(#f24f),hl	;override "Insert disk ..."
 	ld	bc,#0503
 	call	OFFSET
 	ld	hl,#1800+3*10
-	ld	bc,24*10	;ERRORLIST(#1910...) bugfix!! (it was 25*10)
+	ld	bc,24*10	;ERRORLIST(#1910...) bug fix!! (it was 25*10)
 	xor	a
-	call	FILLVRAM	;wis blinktabel (regel 3-27)
+	call	FILLVRAM	;clear blink table (lines 3-27)
 	ld	hl,3*80
 	ld	de,Disklines
 	call	PRINTBLOK
@@ -1163,7 +1163,7 @@ diskhoofd	ld	sp,(Sp_disk)
 	jp	z,_diskbackup
 	cp	"T"-"A"+1
 	jp	z,_disktype
-	ld	d,a	;ALTIJD LATEN STAAN !!!
+	ld	d,a	;ALWAYS LEAVE !!!
 	ld	a,(matrix+6)
 	and	%00000010
 	jr	nz,_disk_noctrl
@@ -1265,7 +1265,7 @@ _diskspace	ld	a,(Diskmenu)
 _ctrl1234	call	WISKEYBUFFER
 	ld	a,(Bronprog)
 	dec	a
-	ld	b,a	;dit is anders in v1.1 tov v1.0
+	ld	b,a	;this is different in v1.1 compared to v1.0
 	ld	a,(Diskasm)	;
 	or	b	;
 	jp	nz,diskhoofd
@@ -1318,7 +1318,7 @@ _diskdir	call	inputpath
 	or	a
 	call	nz,filemenu
 	jp	diskhoofd
-;--Mkdir (komt alleen hier in dos2)
+;--Mkdir (only comes here in dos2)
 _diskmkdir	ld	hl,pathnamebuf
 	ld	de,kbuf
 	ld	bc,64
@@ -1328,7 +1328,7 @@ _diskmkdir	ld	hl,pathnamebuf
 	or	a
 	sbc	hl,de
 	ld	de,kbuf
-	add	hl,de	;Doel directorynaam
+	add	hl,de	;Target directory name
 	ex	de,hl
 	ld	hl,fcb_work+1
 	ld	b,8
@@ -1347,7 +1347,7 @@ _diskmkdir1	xor	a
 	xor	a
 	ld	c,#44
 	ld	de,kbuf
-	call	bdos	;Create file-handle
+	call	bdos	;Create file handle
 	cp	#cb
 	jp	nz,diskhoofd
 _mkdirerr	call	inidir
@@ -1448,7 +1448,7 @@ _formjon	inc	hl
 	ld	a,(hl)
 	ld	h,#40
 	call	SLOT
-	call	#4019	;get choiceadress
+	call	#4019	;get choice address
 	ld	a,h
 	or	l
 	call	nz,formoptie
@@ -1541,7 +1541,7 @@ _diskloadcnt	add	hl,de
 	ex	de,hl
 	ld	de,fcb_work
 	ld	ix,(Pointer)
-	ld	iy,writeerror	;ZO LATEN !!!
+	ld	iy,writeerror	;LEAVE IT !!!
 	jp	(hl)
 Jp_loads:	defw	_load_asm,_load_asc,_load_bin,_load_data
 	defw	_load_blk,_load_sect
@@ -1553,7 +1553,7 @@ _disk_asm	ld	a,1
 	jp	nz,writeerror
 	ld	de,fcb_work
 	ld	ix,(Pointer)
-	ld	iy,writeerror	;ZO LATEN !!!
+	ld	iy,writeerror	;LEAVE IT !!!
 	ld	a,(Diskasm)
 	dec	a
 	jr	nz,_noasmdisk
@@ -1577,7 +1577,7 @@ _load_asc	ld	l,(ix+4)
 _load_blk	ld	l,(ix+8)
 	ld	h,(ix+9)
 	jp	(hl)
-_load_bin	ld	de,Binldheader	;LOAD BINAIR FILE
+_load_bin	ld	de,Binldheader	;LOAD BINARY FILE
 	call	set_DTA
 	ld	hl,7
 	call	fcb_read
@@ -1585,7 +1585,7 @@ _load_bin	ld	de,Binldheader	;LOAD BINAIR FILE
 	cp	#fe
 	jr	nz,_nobinfile
 	call	printbin
-loadbincont:	;Aanroep vanuit datafile laden
+loadbincont:	;Load call from data file
 	ld	de,buffer1024
 	call	set_DTA
 	ld	hl,(Startldadr)
@@ -1618,7 +1618,7 @@ _loadbin_1:	call	fcb_read
 	pop	de
 	pop	hl
 	add	hl,de
-	ld	(Startldadr),hl	;volgende adres
+	ld	(Startldadr),hl	;next address
 	jr	_loadbin_cnt
 _endloadbin	pop	hl
 	ld	(Startldadr),hl
@@ -1658,7 +1658,7 @@ _load_data	call	wissaveload
 	ld	hl,fcb_work+16
 	ld	e,(hl)
 	inc	hl
-	ld	d,(hl)	;lengte file
+	ld	d,(hl)	;file length
 	ld	(Lengthfile),de
 	dec	de
 	ld	b,4
@@ -1790,7 +1790,7 @@ _disksave	ld	de,buffer1024
 	call	setdirectory
 	ld	a,(Soort)
 	cp	3
-	jr	c,_disksave1	;niet bij asm/asc i.v.m. backup
+	jr	c,_disksave1	;not at asm/asc due to backup
 	cp	6
 	jr	z,_disksave1
 	call	fcb_create
@@ -1863,7 +1863,7 @@ _bin_again3	ld	hl,19*80+17
 	call	printsave
 	ld	hl,7
 	call	savefile
-binsavecont:	;aanroep vanuit data saven
+binsavecont:	;save call from data
 	ld	de,buffer1024
 	call	set_DTA
 	ld	hl,(Startsvadr)
@@ -1921,8 +1921,8 @@ bininput2	ld	hl,18*80+17
 	ld	(Endsvadr),de
 	ex	de,hl
 	ld	de,(Startsvadr)
-	sbc	hl,de	;staat op [NC]
-	jr	c,bininput2	;eindadres < startadres
+	sbc	hl,de	;is set to [NC]
+	jr	c,bininput2	;end address < start address
 	ret
 Binsvheader:	db	#fe
 Startsvadr:	dw	0
@@ -2045,14 +2045,14 @@ inputpath	ld	hl,pathnamebuf
 	ld	de,pathnamebuf+1
 	ld	bc,63
 	ld	(hl),0
-	ldir		;wis oude path
+	ldir		;delete old path
 _inputagain	ld	hl,333+2*80
 	ld	de,pathnamebuf
 	ld	b,63
-	ld	a,%10000001	;[ESC] en start op einde
+	ld	a,%10000001	;[ESC] and start at end
 	call	INPUTTEXT
 	jr	nc,_inputpath1
-	ld	hl,kbuf	;[ESC] gedrukt
+	ld	hl,kbuf	;[ESC] pressed
 	ld	de,pathnamebuf
 	ld	bc,64
 	ldir
@@ -2071,10 +2071,10 @@ _inputpath1	call	testpath
 	ex	de,hl
 	ld	hl,kbuf
 	ld	bc,20
-	ldir		;Naam terug kopieren
+	ldir		;Copy name back
 	call	printpath
 _inputpath2	jp	jon2
-;--print directory op scherm (inclusief directories met < >)
+;--print directory on screen (including directories with < >)
 printdir	call	inidir
 	call	printpath
 	ret	c
@@ -2108,7 +2108,7 @@ _inidir1:	ld	a,0
 	djnz	_inidir2
 	ret
 Vramnaam:	defw	0
-;--print directory op scherm
+;--print directory on screen
 doprintdir	ld	a,(dosversion)
 	dec	a
 	jr	z,_dir_dos1
@@ -2232,7 +2232,7 @@ _dir_dos1_en	ld	a,b
 	ld	b,11
 	jr	z,_dir_dos1_9	;"*.*" 
 	ret
-;--print continue (y/n)UIT:[C]=nee
+;--print continue (y/n)OUT:[C]=no
 prtcontinue	ld	hl,1680+33+80
 	ld	bc,Continue
 	call	PRINTTEKST
@@ -2257,8 +2257,8 @@ prtcontinue	ld	hl,1680+33+80
 	scf
 	ret
 Continue:	defb	"Continue (y/n)",0
-;--print file op scherm met < en > voor directories
-Filename:	defs	14	;<naamnaam.ext>   
+;--print file on screen with < and > for directories
+Filename:	defs	14	;<namename.ext>
 printfile	ld	ix,Filename
 	ld	hl,Filename
 	ld	b,14
@@ -2337,7 +2337,7 @@ _dos2printf2	ld	a,(hl)
 _dos2printf4	ld	a,(hl)
 	inc	hl
 	cp	"."
-	jr	z,_dos2printf4	;HIERMEE OOK BIJ DOS 2 GOED !
+	jr	z,_dos2printf4	;ALSO GOOD WITH DOS 2!
 	ld	(ix+10),a
 	ld	a,(hl)
 	inc	hl
@@ -2346,7 +2346,7 @@ _dos2printf4	ld	a,(hl)
 	ld	(ix+12),a
 	ret
 X_file:	defb	0
-;--Kies een file
+;--Choose a file
 X_file1:	defb	0
 Y_file1:	defb	0
 Filemenu:	defb	0
@@ -2440,9 +2440,9 @@ _filespace	call	haalfile
 	call	jon2
 	call	prtfilenaam
 _filespace1	jp	_fileback
-;----- haal file van scherm   (lege plaatsen worden spaties, zonder ".")
-;----- UIT: filenaam in FILENAME+2, [C]=subdirectory
-haalfile	ld	hl,7*80-12+1	;niet "["
+;----- remove file from screen   (empty places become spaces, without ".")
+;----- OUT: filename in FILENAME+2, [C]=subdirectory
+haalfile	ld	hl,7*80-12+1	;not "["
 	ld	a,(Y_file1)
 	ld	b,a
 	ld	de,80
@@ -2464,7 +2464,7 @@ _haalfile3_1:	ld	(hl),a
 	inc	hl
 	djnz	_haalfile3
 	in	a,(#98)
-	nop		;veranderd tov v1.0 (dos1 puntjesbug)
+	nop		;changed compared to v1.0 (dos1 dots bug)
 	nop
 	ld	b,3
 _haalfile4:	in	a,(#98)
@@ -2505,7 +2505,7 @@ _file_subdi1	ld	b,3
 	ex	de,hl
 	ld	hl,buffer1024
 	ld	bc,20
-	ldir		;Naam terug kopieren
+	ldir		;Copy name back
 	call	printpath
 	call	printdir
 	jp	filemenu
@@ -2525,17 +2525,17 @@ _filebalkad1:	add	a,15
 	add	a,7
 	ld	l,a
 	ret
-;--Menu van soorten files
+;--Menu of types of files
 Soortmenvram:	equ	10*80+31
 Soortmenopt:	defb	1
 soortmenu	ld	a,(Bronprog)
 	ld	ix,Asmfiles+1
 	dec	a
 	jr	z,_soortmenu1
-	ld	ix,Debfiles+1	;Debugger en Monitor gelijk
+	ld	ix,Debfiles+1	;Debugger and Monitor alike
 _soortmenu1	ld	a,(ix-1)
 	ld	de,kbuf
-	ld	(de),a	;verticale hoogte
+	ld	(de),a	;vertical height
 	inc	de
 	ld	a,11
 	ld	(de),a
@@ -2543,7 +2543,7 @@ _soortmenu1	ld	a,(ix-1)
 	xor	a
 	ld	(de),a
 	inc	de
-	ld	a,(ix-1)	;Aantal
+	ld	a,(ix-1)	;Number
 _soortmenu2	ld	l,(ix)
 	inc	ix
 	ld	h,(ix)
@@ -2559,7 +2559,7 @@ _soortmenu2	ld	l,(ix)
 _soortmenu4	ld	a,(Soortmenopt)
 	ld	c,a
 	add	a,10
-	ld	l,a	;MOET !!!
+	ld	l,a	;MUST !!!
 	ld	h,#21
 	ld	ix,kbuf
 	call	KIESOPTIE
@@ -2589,7 +2589,7 @@ setsoort1	ld	a,(Bronprog)
 	dec	a
 	ld	a,(Soort)
 	ld	b,a
-	jr	z,_soortasm	;assembler 
+	jr	z,_soortasm	;assembler
 _soortdeb	cp	3
 	ld	b,1
 	jr	z,_soortasm
@@ -2629,7 +2629,7 @@ Binf	defb	"Binary file"
 Datf	defb	" Data file "
 Blkf	defb	"Block file "
 Sect	defb	"  Sector   "
-;--Print info van disk op scherm
+;--Print info from disk on screen
 prtdskinfo	call	printtype
 	call	printboven
 	call	printpath
@@ -2674,11 +2674,11 @@ _printboven1:	call	WRITEVRAM
 Off:	defb	"off"
 Asm:	defb	"Asm"
 Asc:	defb	"Asc"
-;--print path en drive op scherm
+;--print path and drive on screen
 printpath	ld	hl,6*80+3+10
 	ld	bc,64
 	xor	a
-	call	FILLVRAM	;wis oude path
+	call	FILLVRAM	;delete old path
 	ld	bc,pathnamebuf
 	ld	hl,6*80+3+10
 	call	PRINTTEKST
@@ -2689,7 +2689,7 @@ testpath	LD	A,(dosversion)
 	CP	":"
 	JR	NZ,_nodrv
 	LD	A,(pathnamebuf)
-	AND	#DF	;grote letters only
+	AND	#DF	;big letters only
 	JR	Z,_nodrv
 	SUB	"A"
 	JR	C,_badpath
@@ -2712,8 +2712,8 @@ _pathdos2	LD	DE,pathnamebuf
 	OR	A
 	JP	NZ,_badpath
 _contdrv	LD	B,C
-	LD	A,(drives)	;loginvector
-schuifdrives	RRCA		;is de drive aangesloten?
+	LD	A,(drives)	;login vector
+schuifdrives	RRCA		;is the drive connected?
 	DJNZ	schuifdrives
 	JR	NC,_badpath
 	LD	A,C
@@ -2723,7 +2723,7 @@ schuifdrives	RRCA		;is de drive aangesloten?
 	LD	(fcb_work),A
 	DEC	A
 	LD	(huidigedrive),A
-	LD	E,A	;set defaultdrive
+	LD	E,A	;set default drive
 	LD	C,14
 	CALL	bdos
 	OR	A
@@ -2743,7 +2743,7 @@ txt_badpath	db	"Bad pathname !",0
 
 doinclude	db	0
 
-;--print file naam
+;--print file name
 prtfilenaam	ld	hl,24*80+53+10
 	ld	bc,12
 	xor	a
@@ -2753,8 +2753,8 @@ prtfilenaam	ld	hl,24*80+53+10
 	ex	de,hl
 	ld	de,fcb_work+1
 	ld	bc,11
-	ldir		;filenaam naar FCB
-_prtfilenaam:	;ZO LATEN !!!
+	ldir		;filename to FCB
+_prtfilenaam:	;LEAVE IT !!!
 	ld	hl,24*80+53+10
 	call	SETVRAMWRITE
 	ld	hl,fcb_work+1
@@ -2792,7 +2792,7 @@ _beradrname2	add	a,a
 	ret
 Names:	dw	name_asm,name_asc,name_bin,name_com1,name_blk
 Disknames:	dw	name_com2,name_tsr,name_rel
-;--Bereken en print kB vrij op disk    IN: E=disknr (1-8)
+;--Calculate and print kB free on disk    IN: E=disknr (1-8)
 prtfreedisk	ld	c,#1b
 	inc	e
 	call	bdos
@@ -2805,7 +2805,7 @@ ber_kb	push	hl
 	ld	d,0
 	call	b16_mu
 	ld	b,h	;512=%10, 1024=%100, 2048=%1000
-	pop	hl	;hl=aantal vrije clusters
+	pop	hl	;hl=number of free clusters
 	ld	de,0
 _prtfreedis2:	srl	b	;/2
 	jr	c,_prtfreedis1
@@ -2832,7 +2832,7 @@ setdirectory	LD	A,(dosversion)
 	SBC	HL,DE
 	LD	A,H
 	OR	L
-	RET	Z	;hl gelijk aan de (geen directory)
+	RET	Z	;hl equal to de (no directory)
 	LD	B,H
 	LD	C,L
 	EX	DE,HL
@@ -2874,11 +2874,11 @@ writeerror	ld	de,fcb_work
 	ld	hl,14*80+(80-17)/2
 	ld	bc,Writeerror
 	jp	_diskkill2
-;--Maak backup van filenaam in FCB
+;--Back up filename in FCB
 makebackup	ld	hl,fcb_work
 	ld	de,buffer1024
 	ld	bc,1+11+25
-	ldir		;bewaren
+	ldir		;keep
 	ld	hl,fcb_work+1+8
 	ld	(hl),"B"
 	inc	hl
@@ -2898,7 +2898,7 @@ makebackup	ld	hl,fcb_work
 	ldir
 	ld	c,#17
 	ld	de,fcb_work
-	call	bdos	;rename .asm/.asc => .bak 
+	call	bdos	;rename .asm/.asc => .bak
 	ld	hl,buffer1024
 	ld	de,fcb_work
 	ld	bc,1+11+25
@@ -2954,18 +2954,18 @@ Disktext:	defw	6*80+3
 Disktextasm:
 	defb	"  Assemble ",0
 
-;in: DE=pointersnaar tekst HL=startVRAM
+;in: DE=pointersto text HL=startVRAM
 PRINTBLOK	CALL	SETVRAMWRITE
-nxtpointer	EX	DE,HL	;haal pointer naar data
+nxtpointer	EX	DE,HL	;get pointer to data
 	LD	E,(HL)
 	INC	HL
 	LD	D,(HL)
 	INC	HL
-	LD	A,D	;ret als 0000
+	LD	A,D	;ret as 0000
 	OR	E
 	RET	Z
 	EX	DE,HL
-nxtduo	LD	A,(HL)	;get aantal
+nxtduo	LD	A,(HL)	;get number
 	INC	HL
 	OR	A
 	JR	Z,nxtpointer
@@ -2994,20 +2994,20 @@ _texttoblok	LD	A,(HL)
 	OUT	(#98),A
 	JR	_texttoblok
 
-;in:HL=vramadres DE=ramadres B=lengte C=speciaal karakter
-;A: bit0=1:start einde zin bit7=1:escape bit6=1:ook kleine letters
-;   bit5=1:alleen cijfers bit4=1:ook up en down bit3=1:speciaal
+;in:HL=vramaddress DE=ramaddress B=length C=special character
+;A: bit0=1:start end of sentence bit7=1:escape bit6=1:also lowercase
+;bit5=1:only numbers bit4=1:also up and down bit3=1:special
 
 vramadrestxt	dw	0	;1f19
 txtdoel	dw	0	;1f1b
 lengtetext	db	0	;1f1d
 position	db	0	;1f1e 1-..
 	db	0	;1f1f lengte 1-..
-kanescape	db	0	;1f20 0=geen esc mogelijk
-kleinelett	db	0	;1f21 0=geen kleine letters mogelijk
-alleencijf	db	0	;1f22 <>0 alleen cijfers mogelijk
-updown	db	0	;1f23 <>0 ook up en down
-specialchar	db	0	;1f24 <>0 =speciaal karakter
+kanescape	db	0	;1f20 0=no esc possible
+kleinelett	db	0	;1f21 0=no lowercase letters possible
+alleencijf	db	0	;1f22 <>0 only numbers possible
+updown	db	0	;1f23 <>0 also up and down
+specialchar	db	0	;1f24 <>0 =special character
 
 INPUTTEXT	LD	(vramadrestxt),HL
 	LD	(txtdoel),DE
@@ -3092,7 +3092,7 @@ textback	LD	A,#01
 	LD	(DE),A
 	LD	C,(IX+#01)
 	DEC	C
-	jr	z,jon3	;hier zat bug
+	jr	z,jon3	;here was bug
 	LD	B,A
 	CALL	VRAMTORAM
 	XOR	A
@@ -3242,7 +3242,7 @@ textbs_cont	LD	(textbsdel),A
 _text_del1	LD	D,H
 	LD	E,L
 	DEC	DE
-	ld	bc,82	;max lengte+2
+	ld	bc,82	;max length+2
 	LDIR
 	POP	BC
 	POP	HL
@@ -3315,24 +3315,24 @@ CLOSEFILE	LD	DE,fcb_work
 	JP	Z,diskhoofdprt
 	CALL	GETKEY
 	JP	_diskback
-;----- IN: HL=vram-adres, IX=menu-info
+;----- IN: HL=vram address, IX=menu info
 PRINTMENU	ld	a,1
 	ld	(cursoronoff),a
 	push	hl
 	ld	a,(ix+2)
 	or	a
-	ld	de,buffer1024	;1e buffer
+	ld	de,buffer1024	;1st buffer
 	jr	z,_printmenu1
-	ld	de,buffer1024+256	;2e buffer
+	ld	de,buffer1024+256	;2nd buffer
 _printmenu1:	ld	a,(ix)
 	cp	1
 	jr	nz,_not1
 	inc	a
-_not1:	add	a,2+1	;+randen+schaduw
+_not1:	add	a,2+1	;+edges+shadow
 	ld	b,a
 	ld	a,(ix+1)
-	add	a,4+2+2	;+spaties+randen+schaduw
-	ld	c,a	;c=breedte
+	add	a,4+2+2	;+spaces+borders+shadow
+	ld	c,a	;c=width
 _printmenu3:	push	bc
 	call	SETVRAMREAD
 	ld	b,c
@@ -3343,12 +3343,12 @@ _printmenu2:	in	a,(#98)
 	ld	bc,80
 	add	hl,bc
 	pop	bc
-	djnz	_printmenu3	;bewaar ondergrond in buffer
+	djnz	_printmenu3	;save background in buffer
 
 	pop	hl
 	ld	iy,Menuhok
 	ld	a,(ix+1)
-	add	a,4	;breedte+4
+	add	a,4	;width+4
 	ld	(iy+2),a
 	ld	(iy+9),a
 	ld	(iy+20),a
@@ -3360,8 +3360,8 @@ _printmenu2:	in	a,(#98)
 	ld	bc,Menuspeed
 	jp	OFFSET
 Menuspeed:	equ	#0902
-;----- IN: C=optienr, HL=adres blinktabel, IX=info menu
-;----- UIT: A=toets, C=optienr (1-..), HL=adres blinktabel
+;----- IN: C=option num, HL=address blink table, IX=info menu
+;----- OUT: A=key, C=option no (1-..), HL=address blink table
 KIESOPTIE:
 kieshoofd:
 	call	kiessetbalk
@@ -3432,21 +3432,21 @@ kiessetbalk:	push	hl
 	pop	bc
 	pop	hl
 	ret
-;----- IN: IX=menu-info, HL=adres vram
+;----- IN: IX=menu info, HL=address vram
 WISOUDMENU	ld	a,(ix+2)
 	or	a
-	ld	de,buffer1024	;1e buffer
+	ld	de,buffer1024	;1st buffer
 	jr	z,_wisoudmenu1
-	ld	de,buffer1024+256	;2e buffer
+	ld	de,buffer1024+256	;2nd buffer
 _wisoudmenu1:	ld	a,(ix)
 	cp	1
 	jr	nz,_not1_1
 	inc	a
-_not1_1	add	a,2+1	;+randen+schaduw
+_not1_1	add	a,2+1	;+edges+shadow
 	ld	b,a
 	ld	a,(ix+1)
-	add	a,4+2+2	;+spaties+randen+schaduw
-	ld	c,a	;c=breedte
+	add	a,4+2+2	;+spaces+borders+shadow
+	ld	c,a	;c=width
 _wisoudmenu3:	push	bc
 	call	SETVRAMWRITE
 	ld	b,c
@@ -3460,25 +3460,25 @@ _wisoudmenu2:	ld	a,(de)
 	djnz	_wisoudmenu3
 	ld	bc,#0101
 	jp	OFFSET
-;Bereken getal voor assembleren
-;In:HL=beginadres tekst, DE=assembleeradres IX=testlabel-adres
-;   A=eventueel segment (bit 6-7)
+;Calculate number for assembling
+;In:HL=start address text, DE=assemble address IX=test label address
+;A=any segment (bit 6-7)
 BERGETALASM	ld	(Testlabel),ix
 	ld	(Assembladres),de
 	ld	(Segment),a
 	jr	contbergetal
-;In:HL=beginadres tekst,einde =0 of ",=<>"
-;Uit: DE=getal HL=volgend adres Cf=fout,A=foutnr:
-;0=geen getal 1=bad mnemonic 2=mishaaksluit 3=delinndoor0
+;In:HL=start address text,end=0 or ",=<>"
+;Off: DE=number HL=next address Cf=error,A=error no:
+;0=no number 1=bad mnemonic 2=wrong hook close 3=delinndoor0
 Assembladres:	defw	0
 BEREKENGETAL	ld	bc,(Result)
-	ld	(Assembladres),bc	;voor $
+	ld	(Assembladres),bc	;for $
 	ld	bc,Testlabeladr
 	ld	(Testlabel),bc
 contbergetal	ld	(Sp_reken),sp
 	ld	iy,Exist1
-	ld	(iy-2),0	;0 haakjes geopend
-	ld	(iy-3),0	;geen getallen gehad
+	ld	(iy-2),0	;0 brackets open
+	ld	(iy-3),0	;had no numbers
 	xor	a
 	ld	(Fndsegment),a
 	dec	sp
@@ -3507,9 +3507,9 @@ rekenloop	ld	a,(hl)
 Doel_sp1:	ld	de,0
 	ld	hl,Exist1+18
 	ld	bc,20
-	lddr		;info naar stack
+	lddr		;info to stack
 	ex	de,hl
-	ld	sp,hl	;nieuwe SP
+	ld	sp,hl	;new SP
 	exx
 	jp	haakstart
 _reken1	call	haalgetal
@@ -3545,11 +3545,11 @@ Doel_sp2:	ld	hl,0
 	inc	hl
 	ld	de,Exist1-1
 	ld	bc,20
-	ldir		;info van stack
-	ld	sp,hl	;nieuwe SP
+	ldir		;info from stack
+	ld	sp,hl	;new SP
 	dec	sp	;-1
 	exx
-	call	soortfound	;vul in + eventueel berekenen
+	call	soortfound	;fill in + calculate if necessary
 	jp	haaksluit
 _reken2	cp	"^"
 	jr	z,operat
@@ -3570,7 +3570,7 @@ _reken2	cp	"^"
 	cp	"X"
 	jr	z,_xor
 	cp	"M"
-	dec	hl	;Zo laten !!!
+	dec	hl	;Leave it !!!
 	jp	nz,eindereken
 	inc	hl
 _mod	ld	a,(hl)
@@ -3617,7 +3617,7 @@ operat	ld	(de),a
 haalgetal	ex	af,af'
 	xor	a
 	ld	(Newsegment),a
-	ld	(iy-1),0	;sign positief
+	ld	(iy-1),0	;sign positive
 	ex	af,af'
 _haalget_cnt	cp	"+"
 	jp	z,_haalgetal1
@@ -3635,13 +3635,13 @@ _haalget_cnt	cp	"+"
 	jr	nc,soortfound
 	call	testlabel
 	jp	c,badmnemonic
-soortfound	inc	(iy-3)	;getal gevonden
+soortfound	inc	(iy-3)	;number found
 	ld	a,(iy-1)
 	or	a
 	jr	z,_positief
 	push	hl
 	ld	hl,0
-	sbc	hl,de	;maak negatief, staat op [NC]
+	sbc	hl,de	;make negative, set to [NC]
 	ex	de,hl
 	pop	hl
 _positief	push	hl
@@ -3652,20 +3652,20 @@ _findempty:	ld	a,(hl)
 	jr	z,_empty
 	add	hl,bc
 	jr	_findempty
-_empty	ld	(hl),1	;getal bestaat
+_empty	ld	(hl),1	;number exists
 	inc	hl
 	ld	(hl),e
 	inc	hl
 	ld	(hl),d
 	inc	hl
-	ex	de,hl	;de=adres operation
+	ex	de,hl	;de=address operation
 	pop	hl
 testifcount	ld	a,(Exist1+4)
 	or	a
-	call	z,segments	;1e getal => Fndsegment zetten
+	call	z,segments	;1st number => Set Fndsegment
 	ld	a,(Exist1+16)
 	or	a
-	ret	z	;nog niet vol
+	ret	z	;not yet full
 docount	push	hl
 	ld	a,"^"
 	ld	c,1
@@ -3692,7 +3692,7 @@ docount	push	hl
 	call	testifexist
 	jr	nc,doxor
 	pop	hl
-	ret		;niets meer te rekenen
+	ret		;nothing more to count
 doandor	push	hl
 	cp	"A"
 	push	af
@@ -3716,16 +3716,16 @@ cont_optel:	ex	de,hl
 	ld	(hl),d
 	inc	hl
 	xor	a
-	ld	(hl),a	;wis operation volgend getal
+	ld	(hl),a	;clear operation next number
 	inc	hl
-	ld	(hl),a	;wis exist volgend getal
+	ld	(hl),a	;delete exist next number
 	ld	a,(Exist1+4)
 	or	a
 	jr	nz,twee_exist
 	ld	hl,Exist1+7
 	ld	de,Exist1+3
 	ld	bc,4*3
-	ldir		;3 => 2 en 4 => 3 en 5 => 4
+	ldir		;3 => 2 and 4 => 3 and 5 => 4
 	jr	docount_end
 twee_exist	ld	a,(Exist1+8)
 	or	a
@@ -3733,17 +3733,17 @@ twee_exist	ld	a,(Exist1+8)
 	ld	hl,Exist1+11
 	ld	de,Exist1+7
 	ld	bc,4*2
-	ldir		;4 => 3 en 5 => 4
+	ldir		;4 => 3 and 5 => 4
 	jr	docount_end
 drie_exist	ld	a,(Exist1+12)
 	or	a
-	jr	nz,docount_end	;4 bestaat ook, dus 5 gewist
+	jr	nz,docount_end	;4 also exists, so 5 deleted
 	ld	hl,(Exist1+15)
 	ld	(Exist1+11),hl
 	ld	hl,(Exist1+15+2)
 	ld	(Exist1+11+2),hl
 docount_end	ld	hl,0
-	ld	(Exist1+16-1),hl	;wis 5
+	ld	(Exist1+16-1),hl	;delete 5
 	ld	hl,Exist1
 	ld	bc,4
 _findempty1	ld	a,(hl)
@@ -3752,8 +3752,8 @@ _findempty1	ld	a,(hl)
 	add	hl,bc
 	jr	_findempty1
 _empty1	ex	de,hl
-	dec	de	;DE=adres operation
-	pop	hl	;volgende adres
+	dec	de	;DE=address operation
+	pop	hl	;next address
 	ret
 domaal	push	hl
 	call	b16_mu
@@ -3768,8 +3768,8 @@ dodeelmod	push	hl
 	pop	af
 	call	nz,b16_mod
 	jr	cont_optel
-;----- Operation in A of C al gevonden ?   [C]=nee, anders: BC en DE zijn 2
-;      getallen, A=operation
+;----- Operation in A or C already found? [C]=no, otherwise: BC and DE are 2
+;      numbers, A=operation
 testifexist	ld	hl,Exist1+3
 	ld	de,4
 	ld	b,4
@@ -3800,7 +3800,7 @@ _testfound	dec	hl
 	ret
 _haalgetal2	ld	a,(iy-1)
 	xor	1
-	ld	(iy-1),a	;+ wordt - en andersom
+	ld	(iy-1),a	;+ becomes - and vice versa
 _haalgetal1	inc	hl
 	ld	a,(hl)
 	jp	_haalget_cnt
@@ -3820,12 +3820,12 @@ _ready	pop	hl
 	ld	de,(Exist1+1)
 	ld	sp,(Sp_reken)
 	ld	a,(Fndsegment)
-	ret		;[NC] en DE is gevonden getal
+	ret		;[NC] and DE is found number
 Sp_reken:	defw	0
-Segment:	defb	0	;huidig segment bij assembleren
-Fndsegment:	defb	0	;berekende segment
-Newsegment:	defb	0	;segment, behorend bij getal
-;----- FOUTEN
+Segment:	defb	0	;current segment when assembling
+Fndsegment:	defb	0	;calculated segment
+Newsegment:	defb	0	;segment, belonging to number
+;----- FAULTS
 geengetal	xor	a
 	jr	foutback
 badmnemonic	ld	a,1
@@ -3837,10 +3837,10 @@ foutback	ld	sp,(Sp_reken)
 	scf
 	ret
 
-Getalgehad:	defb	0	;0=geen getal gehad
-Haakgeopend:	defb	0	;aantal haakjes geopend
+Getalgehad:	defb	0	;0=didn't have a number
+Haakgeopend:	defb	0	;number of open brackets
 Sign:	defb	0
-Exist1:	defb	0	;0=bestaat niet +0
+Exist1:	defb	0	;0=does not exist +0
 Getal1:	defw	0	;           +1
 Oper1_2:	defb	0	;^*/+-            +3
 	defb	0	;           +4
@@ -3854,10 +3854,10 @@ Oper1_2:	defb	0	;^*/+-            +3
 	defb	0
 	defb	0
 	defw	0
-;----- Vermenigvuldigen
-; Invoer:    BC, DE
-; Uitvoer:   HL = BC * DE
-; Verandert: AF, BC, HL
+;----- Multiply
+; Input:    BC, DE
+; Output:   HL = BC * DE
+; Changes:  AF, BC, HL
 b16_mu	ld	hl,0
 	ld	a,b
 	ld	b,16
@@ -3873,11 +3873,11 @@ segments	ld	a,(Newsegment)
 	or	b
 	ld	(Fndsegment),a
 	ret
-;----- Delen
-; Invoer:    BC, DE
-; Uitvoer:   HL = BC / DE
-;            [C]= deling door 0
-; Verandert: AF, BC, DE, HL
+;----- Shared
+; Input:    BC, DE
+; Output:   HL = BC / DE
+;          [C]= division by 0
+; Changes:  AF, BC, DE, HL
 b16_di	ld	a,d
 	or	e
 	jp	z,delingdoor0
@@ -3887,15 +3887,15 @@ b16_di	ld	a,d
 	jr	nz,b16_d0
 	ld	d,h
 	ld	e,l
-	jr	segments	;Tlr=0 => res HL=0 en DE=0
+	jr	segments	;Tlr=0 => res HL=0 and DE=0
 b16_d0	ld	a,b
 	ld	b,17
 b16_d1	scf
 	rl	c
 	adc	a,a
 	dec	b
-	jr	nc,b16_d1	;Zoek 1e hoge bit
-	;Komt nooit hier met B < 1 !
+	jr	nc,b16_d1	;Find 1st high bit
+	;Never come here with B < 1 !
 b16_d2	adc	hl,hl
 	sbc	hl,de
 	jr	nc,b16_d3
@@ -3910,16 +3910,16 @@ b16_d3	rl	c
 	cpl
 	ld	l,a
 	jr	segments
-;----- Optellen
-; Invoer:  BC, DE
-; Uitvoer: HL = BC + DE
+;----- Adding up
+; Input:  BC, DE
+; Output: HL = BC + DE
 b16_add	ld	h,b
 	ld	l,c
 	add	hl,de
-	jr	segments	;hier stond ret**=calculatorbugv1.0*****
-;----- Aftrekken
-; Invoer:  BC, DE
-; Uitvoer: HL = BC - DE
+	jr	segments	;it said ret**=calculatorbugv1.0*****
+;----- Substract
+; Input:  BC, DE
+; Output: HL = BC - DE
 b16_sub	ld	h,b
 	ld	l,c
 	or	a
@@ -3932,14 +3932,14 @@ b16_sub	ld	h,b
 	pop	bc
 	jr	nz,segments
 	xor	a
-	ld	(Fndsegment),a	;Uitzondering voor segmenten
+	ld	(Fndsegment),a	;Segments exception
 	ret
-; Machtsroutine 16-bits
-; Invoer:    BC,DE
-; Uitvoer:   HL(=BC^DE)
-; Verandert: AF, BC, DE en HL
+; Power Routine 16-bit
+; Input:    BC,DE
+; Output:   HL(=BC^DE)
+; Changes:  AF, BC, DE and HL
 b16_mac	ld	h,d
-	ld	l,e	;hl=aantal maal
+	ld	l,e	;hl=number of times
 	ld	a,h
 	or	l
 	jr	z,_b16m2	;^0
@@ -3951,7 +3951,7 @@ b16_mac	ld	h,d
 	ld	e,c	;de=bc
 _b16m1:	push	hl
 	push	de
-	call	b16_mu	;vermenigvuldig
+	call	b16_mu	;multiply
 	pop	de
 	ld	b,h
 	ld	c,l
@@ -3990,14 +3990,14 @@ b16_xor	ld	a,b
 	ld	l,a
 	jp	segments
 b16_mod	call	b16_di
-	ex	de,hl	;Mod, dus restwaarde
-	ret		;segments al gedaan
+	ex	de,hl	;Mod, so residual value
+	ret		;segments already done
 
-;----- Is hex getal ?     [C]=nee
+;----- Is hex number ?     [C]=no
 testhex:	ld	a,(hl)
 	cp	"A"
 	ccf
-	ret	c	;moet met getal beginnen
+	ret	c	;must start with number
 	push	hl
 	call	testidhexvoo
 	ld	a,0
@@ -4033,10 +4033,10 @@ _testhex_2:	sla	a
 testhex_idna	dec	hl
 	ld	a,c
 	or	a
-	jr	z,testhex_back	;geen hex-getal
+	jr	z,testhex_back	;no hex number
 	ld	a,(Hexidfound)
 	or	a	;=[NC]
-	call	z,testidhexna	;nog geen id
+	call	z,testidhexna	;no id yet
 	jr	c,testhex_back
 	pop	bc
 	ret
@@ -4044,7 +4044,7 @@ testhex_back:	pop	hl
 	scf
 	ret
 Hexidfound	db	0
-;----- Is bin getal ?     [C]=nee
+;----- Is bin number ?     [C]=no
 testbin	push	hl
 	call	testidbinvoo
 	ld	a,0
@@ -4070,10 +4070,10 @@ _testbin_1:	ld	a,(hl)
 testbin_idna	dec	hl
 	ld	a,c
 	or	a
-	jr	z,testbin_back	;geen bin-getal
+	jr	z,testbin_back	;no bin number
 	ld	a,(Binidfound)
 	or	a	;=[NC]
-	call	z,testidbinna	;nog geen id
+	call	z,testidbinna	;no id yet
 	jr	c,testbin_back
 	pop	bc
 	ret
@@ -4081,7 +4081,7 @@ testbin_back:	pop	hl
 	scf
 	ret
 Binidfound	db	0
-;----- Is dec getal ?    [C]=nee
+;----- Is dec number ?    [C]=no
 testdec	push	hl
 	ld	de,0
 	exx
@@ -4116,7 +4116,7 @@ testdec_na	dec	hl
 	ld	a,c
 	exx
 	or	a
-	jr	z,testdec_back	;geen dec getal
+	jr	z,testdec_back	;no dec number
 	pop	bc
 	ret
 testdec_back	pop	hl
@@ -4145,12 +4145,12 @@ _iskar	ld	b,a
 	ld	a,(hl)
 	cp	b
 	ld	de,0
-	jr	z,_2quotes	;"" of ''
+	jr	z,_2quotes	;"" or ''
 	ld	e,a
 	inc	hl
 	ld	a,(hl)
 	cp	b
-	jr	z,_2quotes	;"?" of '?'
+	jr	z,_2quotes	;"?" or '?'
 	ld	d,e
 	ld	e,a
 	inc	hl
@@ -4177,7 +4177,7 @@ Testlabel:	equ	$+1
 	call	zetslot
 	pop	af
 	ret
-;----- test id's binair en hexadecimaal
+;----- test ids binary and hexadecimal
 testidbinvoo	ld	ix,idbin
 	ld	a,(ix+2)
 	or	a
@@ -4249,7 +4249,7 @@ testspecid	ld	b,(hl)
 	and	%11011111
 	cp	b
 	scf
-	ret	nz	;geen id
+	ret	nz	;no id
 	inc	hl
 	ld	a,(ix+1)
 	or	a
@@ -4264,14 +4264,14 @@ testspecid	ld	b,(hl)
 	dec	hl
 	dec	hl
 	scf
-	ret		;geen id
+	ret		;no id
 
-MEMVIEW	LD	HL,#1800+3*10	;blinktabel uit,behalve menubalk
+MEMVIEW	LD	HL,#1800+3*10	;blink table except menu bar
 	LD	BC,24*10
 	XOR	A
 	CALL	FILLVRAM
-	LD	HL,3*80	;scherm wissen (laatste halve regel
-	LD	BC,23*80	;is steeds leeg)
+	LD	HL,3*80	;clear screen (last half line
+	LD	BC,23*80	;is always empty)
 	XOR	A
 	CALL	FILLVRAM
 	CALL	printmemview
@@ -4313,7 +4313,7 @@ _calccontinu	push	af
 	ld	hl,(Calcdoelblin)
 	ld	bc,5*10
 	xor	a
-	call	FILLVRAM	;wis blink
+	call	FILLVRAM	;clear blink
 	ld	hl,(Calcdoel)
 	ld	de,Calculalines
 	call	PRINTBLOK
@@ -4411,7 +4411,7 @@ _calc_cont	ld	hl,(Calcdoel)
 	add	hl,de
 	ld	de,buffer1024
 	ld	b,80-13-2
-	ld	a,%11010001	;escape, kleine letters, up/down, achter
+	ld	a,%11010001	;escape, lowercase, up/down, back
 	call	INPUTTEXT
 	jr	c,_calc_esc
 	ld	hl,buffer1024
@@ -4549,7 +4549,7 @@ Mt_2:	defb	"2",0
 Mt_3:	defb	"3",0
 Mt_4:	defb	"4",0
 Mt6:	defb	"Memory manager:",0
-	;*****************eventueel de 1 bij source1 en data1 wegdoen
+	;*****************possibly remove the 1 from source1 and data1
 Memorylines:	defw	M1,M2,M3,M4,M5
 	defw	M6,M7,M6,M7,M6,M7,M6,M7,M6,M7,M6,M7
 	defw	M6,M8,M6,M9,M6,M10,M6,M9,M6,M9,M6,M9,M6,M9,M6,M11
@@ -4572,7 +4572,7 @@ M11:	defb	1,20,9,23,1,17,9,23,1,17,18,23,1,19,0
 M12:	defb	1,22,38,0,1,22,0
 M13:	defb	1,26,9,23,1,17,9,23,1,17,9,23,1,17,9,23,1,17,38,23,1,27,0
 
-;print klein blok op scherm: in:HL=vramadres DE=info-adres
+;print small block on screen: in:HL=vramadres DE=info-adress
 _printblokkl	POP	HL
 	EX	DE,HL
 	LD	BC,80
@@ -4601,7 +4601,7 @@ _printblokk2	NOP
 	DJNZ	_printblokk2
 	JR	_printblokk3
 
-;in: HL=adres data (4bytes)=uit te voeren instructie uit:HL:registertabel
+;in: HL=address data (4bytes)=instruction to execute out:HL:register table
 STARTPROGRAM	LD	DE,data
 	LD	BC,4
 	LDIR
@@ -4627,16 +4627,16 @@ STARTPROGRAM	LD	DE,data
 	LD	A,(page1+1)
 	CALL	SETPAGE1_DOS2
 	DI
-	LD	HL,(#F38C)	;sla originele routine op
+	LD	HL,(#F38C)	;save original routine
 	LD	(old_f38c+1-new_f38c+kbuf),HL
 	LD	HL,(#F38E)
 	LD	(old_f38e+1-new_f38c+kbuf),HL
-	LD	A,#C3	;buig 'hook #001c' af naar kbuf
+	LD	A,#C3	;deflect 'hook #001c' to kbuf
 	LD	(#F38C),A
 	LD	HL,kbuf
 	LD	(#F38D),HL
 	LD	IY,(page0-1)
-	LD	IX,#0000	;eerst page 0 goedschakelen
+	LD	IX,#0000	;first clear page 0
 	CALL	#001C	;START!!!
 	LD	HL,#FFFF
 	LD	(oudslot),HL
@@ -4649,11 +4649,11 @@ STARTPROGRAM	LD	DE,data
 GETREGISTERS	LD	HL,registers
 	RET
 new_f38c	OUT	(#A8),A
-new_blok	LD	A,0	;ingevuld
+new_blok	LD	A,0	;filled in
 	call	SETPAGE0_DOS2
-old_f38c	LD	HL,0	;ingevuld: HERSTEL F38C
+old_f38c	LD	HL,0	;filled in: RESTORE F38C
 	LD	(#F38C),HL
-old_f38e	LD	HL,0	;ingevuld
+old_f38e	LD	HL,0	;filled in
 	LD	(#F38E),HL
 	POP	AF
 	LD	(old_a8-new_f38c+kbuf+1),A
@@ -4680,21 +4680,21 @@ no_ei	LD	BC,(reg_bc_-new_f38c+kbuf)	;BC'
 	LD	IX,(reg_ix-new_f38c+kbuf)
 	LD	IY,(reg_iy-new_f38c+kbuf)
 	LD	SP,(reg_sp-new_f38c+kbuf)
-data	ds	4,0	;ingevuld: execute
+data	ds	4,0	;filled in: execute
 	LD	(reg_sp-new_f38c+kbuf),SP
 	LD	SP,(old_sp-new_f38c+kbuf)
 	PUSH	AF
-	LD	A,I	;haal interrupttoestand
+	LD	A,I	;get interrupt state
 	LD	A,#00
 	JP	PO,_eidi-new_f38c+kbuf
 	INC	A
 _eidi	PUSH	AF
 	DI
-old_a8	LD	A,#00	;ingevuld
+old_a8	LD	A,#00	;filled in
 	OUT	(#A8),A
-old_ffff	LD	A,#00	;ingevuld
+old_ffff	LD	A,#00	;filled in
 	LD	(#FFFF),A
-old_blok	LD	A,#00	;ingevuld
+old_blok	LD	A,#00	;filled in
 	CALL	SETPAGE0_DOS2
 	LD	(reg_iy),IY
 	LD	(reg_ix),IX
@@ -4717,7 +4717,7 @@ old_blok	LD	A,#00	;ingevuld
 	LD	(reg_af_),HL
 	RET
 registers
-reg_sp	dw	0	;wordt door startcompass ingevuld
+reg_sp	dw	0	;is filled in by startcompass
 reg_iy	dw	0
 reg_ix	dw	0
 reg_bc_	dw	0
@@ -4751,7 +4751,7 @@ GOTOEDITOR	LD	(invul_call1),HL
 goto_cont	LD	(slotsubroutin),BC
 	CALL	zetslot
 	POP	BC
-	POP	HL	;haal tab_memory
+	POP	HL	;get tab_memory
 	db	#cd	;call
 invul_call1	dw	0
 	PUSH	BC
@@ -4797,7 +4797,7 @@ _slot1	RLCA
 	JR	NC,_slot2
 	INC	HL
 _slot2	POP	AF
-	CP	(HL)	;stond dit slot reeds aangeschakeld?
+	CP	(HL)	;was this slot already switched on?
 	LD	(HL),A
 	POP	HL
 	RET	Z
@@ -4810,7 +4810,7 @@ _slot2	POP	AF
 	POP	DE
 	RET
 oudslot	db	#ff,#ff,#ff,#ff
-stat_getkey	db	0	;invoer maar mogelijk met Linkervuurknop
+stat_getkey	db	0	;input only possible with Left fire button
 GETKEY2	ld	a,1
 	ld	(stat_getkey),a
 GETKEY	PUSH	HL
@@ -4820,46 +4820,46 @@ GETKEY	PUSH	HL
 	OR	A
 	JR	Z,not_visible
 wait1	LD	B,#00
-	CALL	WAITFORKEY	;wacht op een toets en verzorg intussen
-	JR	C,wait1	;ook de ctrl56,R800/Z80
+	CALL	WAITFORKEY	;wait for a key and monitor in the meantime
+	JR	C,wait1	;also the ctrl56,R800/Z80
 	JP	getkey_back
-not_visible	LD	BC,(#F3DC)	;get cursorpositie C=y(1-80) B=x(1-80)
+not_visible	LD	BC,(#F3DC)	;get cursor position C=y(1-80) B=x(1-80)
 	CALL	beradresvram
 	CALL	READVRAM
 	PUSH	AF
 	PUSH	HL
-	LD	L,A	;karnr *8
+	LD	L,A	;char num *8
 	LD	H,#00
 	ADD	HL,HL
 	ADD	HL,HL
 	ADD	HL,HL
-	LD	DE,#1000	;patroontabel
+	LD	DE,#1000	;pattern table
 	ADD	HL,DE
 	CALL	SETVRAMREAD
-	LD	B,8	;default normaalcursor
+	LD	B,8	;default normal cursor
 	LD	HL,blokvorm
 	LD	DE,oldvorm
 	LD	A,(insonoff)
 	OR	A
 	JR	Z,no_ins
 	LD	B,5
-_getkey1	IN	A,(#98)	;bij ins bovenste 5 lijnen onveranderd
+_getkey1	IN	A,(#98)	;at ins top 5 lines unchanged
 	LD	(DE),A
 	INC	DE
 	LD	(HL),A
 	INC	HL
 	DJNZ	_getkey1
 	LD	B,#03
-no_ins	IN	A,(#98)	;de rest inverteren
+no_ins	IN	A,(#98)	;invert the rest
 	LD	(DE),A
 	INC	DE
 	XOR	#FC
 	LD	(HL),A
 	INC	HL
 	DJNZ	no_ins
-	POP	HL	;naamtabellocatie
+	POP	HL	;name table location
 	PUSH	HL
-	LD	A,#FF	;plaat karakter 255
+	LD	A,#FF	;print character 255
 	CALL	WRITEVRAM
 _getkey4	LD	HL,blokvorm
 	LD	DE,#1000+255*8
@@ -4878,9 +4878,9 @@ _getkey3	LD	B,20
 	LD	B,10
 	CALL	WAITFORKEY
 	JR	C,_getkey4
-_getkey2	LD	(invul_lda+1),A	;stel code veilig
-	POP	HL	;haal naamtabeladres
-	POP	AF	;haal oud karakter
+_getkey2	LD	(invul_lda+1),A	;safe code
+	POP	HL	;get name table address
+	POP	AF	;get old character
 	CALL	WRITEVRAM
 	LD	HL,#1000+255*8
 	LD	BC,8
@@ -4899,7 +4899,7 @@ oldvorm	ds	8,0
 blokvorm	ds	8,0
 
 WAITFORKEY	PUSH	BC
-	CALL	rdmous	;muisafhandeling
+	CALL	rdmous	;mouse handling
 	CALL	janeetoetsen	;Z80/R800
 	CALL	hertztoetsen	;ctrl+5/6
 	POP	BC
@@ -4915,20 +4915,20 @@ no1234_0	RRCA
 	INC	E
 	DEC	D
 	JR	NZ,no1234_0
-no1234_1	LD	HL,(#F3FA)	;pointer eerste teken in buffer
-	LD	A,(#F3F8)	;pointer voor nieuw teken
-	CP	L	;gelijk? (dan is de buffer leeg)
-	JR	NZ,_waitforkey	;nee! haal gewoon teken af
-	LD	A,(matrix+7)	;op STOP gedrukt?
+no1234_1	LD	HL,(#F3FA)	;pointer first character in buffer
+	LD	A,(#F3F8)	;pointer for new character
+	CP	L	;equal? (then the buffer is empty)
+	JR	NZ,_waitforkey	;new! just pick up sign
+	LD	A,(matrix+7)	;pressed STOP?
 	AND	#10
-	JR	NZ,_waitforkey2	;nee
-_waitforkey3	LD	A,(matrix+7)	;ja, wacht tot ze uit is
+	JR	NZ,_waitforkey2	;new
+_waitforkey3	LD	A,(matrix+7)	;yes, wait till it's out
 	AND	#10
 	JR	Z,_waitforkey3
-	LD	A,250	;geef code 250 weer, carry gewist
+	LD	A,250	;display code 250, carry cleared
 	RET
-_waitforkey2	LD	A,B	;is tijd op
-	OR	A	;(wacht B interrupts)
+_waitforkey2	LD	A,B	;is up time
+	OR	A	;(wait B interrupts)
 	SCF
 	RET	Z
 	HALT
@@ -4949,14 +4949,14 @@ _waitforkey	ld	a,(hl)
 	LD	HL,#FBF0
 _waitforkey1	LD	(#F3FA),HL
 	POP	AF
-	OR	A	;wis carry, toets in a en buffer kleiner
+	OR	A	;clear carry, key in a and buffer smaller
 	RET
 
 LINETOASSEMB	PUSH	HL
 	LD	HL,#4006
 	JP	GOTOEDITOR
 
-;in: b=x(1-80) c=y(1-27) uit:hl=vramadres,verandert: B,DE,HL,F
+;in: b=x(1-80) c=y(1-27) out:hl=vramaddress,changes: B,DE,HL,F
 beradresvram	LD	H,#00
 	LD	L,B
 	DEC	HL
@@ -4971,18 +4971,18 @@ WISKEYBUFFER	LD	HL,(#F3F8)
 	LD	(#F3FA),HL
 	RET
 
-PUSHANYKEY	LD	HL,#1800+10*24	;in blinktabel
-	LD	BC,10	;80 tekens! breed
+PUSHANYKEY	LD	HL,#1800+10*24	;in blink table
+	LD	BC,10	;80 characters! wide
 	LD	A,#FF
-	CALL	FILLVRAM	;balk
+	CALL	FILLVRAM	;bar
 _pushloop1	CALL	wispushany
-	LD	B,10	;wacht 10 interrupts
+	LD	B,10	;wait 10 interrupts
 	CALL	WAITFORKEY
 	JR	NC,_push_back
 	LD	HL,80*24+(80-12)/2
 	LD	BC,txt_pushany
 	CALL	PRINTTEKST
-	LD	B,20	;wacht 20 interrupts
+	LD	B,20	;wait 20 interrupts
 	CALL	WAITFORKEY
 	JR	C,_pushloop1
 _push_back	LD	HL,#1800+10*24
@@ -5004,11 +5004,11 @@ _printini0	LD	A,(HL)
 	CP	"^"
 	JR	NZ,_printini1
 	LD	A,27
-_printini1	ld	b,0	;probeer 256 keer
+_printini1	ld	b,0	;try 256 times
 _retrysend	CALL	gobios
 	jr	nc,_printini0
 	djnz	_retrysend
-	JR	_printini0	;probeer de volgende tekens dan maar
+	JR	_printini0	;try the following characters
 
 MAININSTALL	LD	BC,(slotsubroutin)
 	LD	(oldslotsub+1),BC
@@ -5030,32 +5030,32 @@ tab_inst
 idhex	db	"#",0,0
 idbin	db	"%",0,0
 printerline	ds	16,0
-mouse	db	0	;1=on, standaard afzetten
+mouse	db	0	;1=on, turn off by default
 knipper	db	1	;1=on
 startlogo	db	1	;1=on
 
-SAVEINSTALL	LD	A,(Backuponoff)	;backupstatus
+SAVEINSTALL	LD	A,(Backuponoff)	;backup status
 	LD	(kbuf+#0104),A
-	LD	HL,#0101	;notnew+notsrcmem
+	LD	HL,#0101	;notnew+notsrcem
 	LD	(kbuf),HL
-	LD	HL,tab_memtabel	;memconfigtabel
+	LD	HL,tab_memtabel	;memconfig table
 	LD	DE,kbuf+2
 	LD	BC,#C1
 	LDIR
-	ld	hl,tab_compass	;compassblocks
+	ld	hl,tab_compass	;compass blocks
 	ld	bc,8
 	ldir
-	ld	hl,tab_memory	;memorystatus
+	ld	hl,tab_memory	;memory status
 	ld	bc,8
 	ldir
 
-	LD	HL,(color)	;paletbytes color 0,(0)
+	LD	HL,(color)	;palettebytes color 0,(0)
 	LD	(kbuf+#ec),HL
-	LD	HL,(color+30)	;paletbytes color 1,(15)
+	LD	HL,(color+30)	;palettebytes color 1,(15)
 	LD	(kbuf+#ee),HL
-	LD	HL,(color+6)	;paletbytes color 2,(3)
+	LD	HL,(color+6)	;palettebytes color 2,(3)
 	LD	(kbuf+#f0),HL
-	LD	HL,(color+4)	;paletbytes color 3,(2)
+	LD	HL,(color+4)	;palettebytes color 3,(2)
 	LD	(kbuf+#f2),HL
 
 	LD	BC,(sloteditor)
@@ -5077,10 +5077,10 @@ SAVEINSTALL	LD	A,(Backuponoff)	;backupstatus
 	LD	HL,compasscom
 	LD	DE,buffer1024+750
 	LD	BC,#FF6B
-	CALL	bdos	;get envitem COMPASS (geeft een
+	CALL	bdos	;get envitem COMPASS (gives a
 	LD	DE,buffer1024+750
-	XOR	A	;nulstring terug als het niet meer is)
-	LD	C,#43	;open filehandle
+	XOR	A	;null string back if not exists)
+	LD	C,#43	;open file handle
 	CALL	bdos
 	JR	skip_opendos1
 openfile_dos1	LD	HL,compasscom
@@ -5099,7 +5099,7 @@ si_place1	dw	#0300
 	CALL	set_DTA
 	db	#21	;ld hl,nn
 si_lenght	dw	#011C
-	CALL	saven_maar	;saven en sluiten
+	CALL	saven_maar	;save and close
 	JR	skip_save_err
 _saveerror	LD	HL,22*80+31
 	LD	BC,Writeerror
@@ -5107,8 +5107,8 @@ _saveerror	LD	HL,22*80+31
 	CALL	beep
 	CALL	GETKEY
 skip_save_err	CALL	clrdiskhooks
-	LD	HL,22*80	;ev errortekst wissen?
-	LD	BC,80	;lijn 22 wissen
+	LD	HL,22*80	;ev delete error text?
+	LD	BC,80	;clear line 22
 	XOR	A
 	JP	FILLVRAM
 
@@ -5139,33 +5139,33 @@ handle_nr	db	0
 save_dos1	LD	DE,fcb_work
 	LD	C,38
 	PUSH	DE
-	CALL	bdos	;saven
+	CALL	bdos	;save
 	POP	DE
-	LD	C,#10	;en sluiten
+	LD	C,#10	;and close
 	JP	bdos
 compasscom	db	"COMPASS COM"
 
-GETPAGES	ld	hl,page0	;(2 keer ld de,nn)
+GETPAGES	ld	hl,page0	;(2 times ld de,nn)
 	ret
-;verplaatst compassblock:c=oudslot B=oud blok (DUS OMGEDRAAID),HL=pointer2nieuw
+;moved compassblock:c=oldslot B=old block (THUS REVERSE),HL=pointer2new
 MOVEPROG	LD	DE,#FFFF
 	LD	(oudslot+1),DE
 	LD	E,(HL)
 	INC	HL
 	LD	D,(HL)
 	LD	HL,(sub)
-	CALL	testmove	;verander inhoud sub als het dat segm
-	LD	(sub),HL	;is dat veranderd gaat worden
+	CALL	testmove	;change content sub if it's that segm
+	LD	(sub),HL	;that is going to be changed
 	LD	HL,(slotsubroutin)
-	CALL	testmove	;idem inhoud slotsubroutin
+	CALL	testmove	;ditto content slot subroutin
 	LD	(slotsubroutin),HL
-	PUSH	DE	;ED bevat het nieuwe, BC het oude
-	LD	A,B	;schakel oude page aan op page1
+	PUSH	DE	;ED contains the new, BC the old
+	LD	A,B	;enable old page on page1
 	CALL	SETPAGE1_DOS2
 	LD	A,C
 	LD	H,#40
 	CALL	SLOT
-	POP	BC	;schakel nieuwe aan op page2
+	POP	BC	;enable new ones on page2
 	LD	A,B
 	CALL	SETPAGE2_DOS2
 	LD	A,C
@@ -5173,7 +5173,7 @@ MOVEPROG	LD	DE,#FFFF
 	CALL	SLOT
 	LD	HL,#4000
 	LD	DE,#8000
-	ld	b,h	;1byte winst (LD BC,#4000)
+	ld	b,h	;1byte gain (LD BC,#4000)
 	ld	c,l
 	LDIR
 	LD	HL,(slotsubroutin)
@@ -5209,7 +5209,7 @@ testmove	ld	a,h
 	ld	l,e
 	ret
 
-;----- naam invoeren
+;----- enter name
 Nameadres:	defw	0
 Posname:	defb	0
 
@@ -5317,7 +5317,7 @@ _quitinput1	call	beradrname
 	jr	c,_quitinput2
 	ld	hl,fcb_work+1
 	ld	bc,11
-	ldir		;filenaam naar FCB 
+	ldir		;filename to FCB
 	call	jon2
 	call	prtfilenaam
 _quitinput2	ld	a,1
@@ -5327,7 +5327,7 @@ _quitinput2	ld	a,1
 	call	WISBALK
 	jp	diskhoofdprt
 
-;------  speciale errors
+;------ special errors
 Errors:	defw	Protected,Offline,Ioerror,Ioerror,Ioerror,Writeerror
 	defw	Ioerror,Ioerror
 Protected:	defb	"Write protected !",0
@@ -5345,7 +5345,7 @@ Specialerr1	push	hl
 	push	bc
 	ld	a,(Asmbusy)
 	or	a
-	call	z,inidir	;schermpje leeg
+	call	z,inidir	;screen blank
 	pop	bc
 	push	bc
 	ld	a,c
@@ -5377,7 +5377,7 @@ _specialer1	push	hl
 	call	z,inidir
 	ld	hl,18*80
 	ld	b,3
-	call	inidircont	;ZO LATEN !
+	call	inidircont	;LEAVE IT !
 	pop	af
 	and	%11011111
 	jr	z,_retry
@@ -5393,7 +5393,7 @@ _specialer1	push	hl
 	and	%00001100
 	ld	de,fcb_work
 	ld	c,#10
-	call	nz,bdos	;close file (niet bij offline/protected)
+	call	nz,bdos	;close file (not with offline/protected)
 	ld	sp,(Sp_disk)
 	jp	diskerrcont
 _retry:	pop	bc
@@ -5442,7 +5442,7 @@ _printlineh1:	nop
 _printhoktxt	ld	a,b
 	cp	3
 	ld	a,0
-	jr	c,_printlineh1	;toch hok
+	jr	c,_printlineh1	;anyway huh
 	ld	a,0
 	out	(#98),a
 	ld	a,0
@@ -5461,10 +5461,10 @@ _printhoktx1:	ld	a,(ix)
 	out	(#98),a
 	jr	_printlineh2
 
-Menuhok	defb	1,24,0,23,1,25,0	;boven
-	defb	1,22,0, 0,1,20,1,23,1,25,0	;1e regel
-	defb	1,22,0, 0,1,22,1,0,1,22,0	;middenstuk
-Menuhokcont	defb	1,26,1,23,1,18,0,23,1,27,1,0,1,22,0	;1e onder menu
+Menuhok	defb	1,24,0,23,1,25,0	;above
+	defb	1,22,0, 0,1,20,1,23,1,25,0	;1st line
+	defb	1,22,0, 0,1,22,1,0,1,22,0	;middle part
+Menuhokcont	defb	1,26,1,23,1,18,0,23,1,27,1,0,1,22,0	;1st under menu
 	defb	2,0,1,26, 0,23,1,27,0
 printmemview	ld	ix,#fcc1
 	ld	iy,Doelhokken
@@ -5474,7 +5474,7 @@ _memview3	push	bc
 	sub	b
 	ld	(Primairslot),a
 	ld	l,(iy)
-	ld	h,(iy+1)	;doel vram
+	ld	h,(iy+1)	;target ask
 	bit	7,(ix)
 	ld	b,4
 	jr	nz,_memview1
@@ -5502,12 +5502,12 @@ _memview2:	push	bc
 	ld	de,9
 	add	hl,de
 	pop	bc
-	djnz	_memview1	;print alle subsloten (1 of 4)
+	djnz	_memview1	;print all subslots (1 or 4)
 	inc	iy
 	inc	iy
 	inc	ix
 	pop	bc
-	djnz	_memview3	;alle primaire sloten
+	djnz	_memview3	;all primary slots
 	ld	hl,4*80+37
 	ld	b,2
 _memviewget1	push	bc
@@ -5568,7 +5568,7 @@ _vultabel2	push	bc
 mapper	ld	a,b
 	cp	2
 	ld	bc,Ram
-	jr	nz,_ram	;Ram, ....kB, Ram, Ram
+	jr	nz,_ram	;Ram, .... kB, Ram, Ram
 	ex	de,hl
 	ld	l,(ix+1)
 	ld	h,0
@@ -5603,7 +5603,7 @@ _leeg:	ld	de,16*2
 	add	hl,de
 	ld	bc,Ram
 	pop	hl
-	call	c,PRINTTEKST	;ook Ram in page 3 als er >=48kB is
+	call	c,PRINTTEKST	;also Ram in page 3 if there is >=48kB
 	pop	ix
 	inc	ix
 	inc	ix
@@ -5633,7 +5633,7 @@ _nextdiskrom:	push	bc
 	jr	z,_nextdromtst
 	ld	c,1
 	ld	hl,Memviewtxt4
-	call	printinblok	;Disk-rom in page 1
+	call	printinblok	;Disk ROM in page 1
 	ld	a,(ix)
 	add	a,"0"
 	out	(#98),a
@@ -5696,7 +5696,7 @@ _foundit	pop	de
 	ret
 Opll:	defb	"OPLL",0
 Musicbox:	defb	"MUSICBOX",0
-;---- IN: A=slot, C=page, HL=tekst
+;---- IN: A=slot, C=page, HL=text
 printinblok	push	hl
 	ld	b,c
 	inc	b
@@ -5705,11 +5705,11 @@ printinblok	push	hl
 _printinblk1:	add	hl,de
 	djnz	_printinblk1
 	bit	0,a
-	jr	z,_printinblk2	;vooraan bij slot 0 en 2
+	jr	z,_printinblk2	;in front at slot 0 and 2
 	ld	de,44
 	add	hl,de
 _printinblk2:	bit	1,a
-	jr	z,_printinblk4	;bovenaan bij slot 0 en 1
+	jr	z,_printinblk4	;at the top at slot 0 and 1
 	ld	de,11*80
 	add	hl,de
 _printinblk4:	and	%1100
@@ -5757,9 +5757,9 @@ _onelinehok1:	out	(#98),a
 	ret
 Doelhokken:	defw	3*80,3*80+44,14*80,14*80+44
 
-;**********************MUISBESTURING*************************************
-mseprt	equ	#fc82	;muispoortnummer, 0=not found
-OFFSET	LD	A,B	;mouseoffsets
+;********************** MOUSE CONTROL*************************************
+mseprt	equ	#fc82	;mouse port number, 0=not found
+OFFSET	LD	A,B	;mouse offsets
 	LD	(MAXOFF),A
 	SRL	A
 	LD	(OFFST),A
@@ -5772,35 +5772,35 @@ rdmous	LD	A,(mouse)
 	OR	A
 	RET	Z
 	DI
-	CALL	fill_delay	;vul juist delayadres in in getpadrout
-	LD	A,#10	;ingang1,pin8ingang1 hoog,pin8ing2laag
+	CALL	fill_delay	;enter correct delay address in getpadrout
+	LD	A,#10	;input1,pin8input1 high,pin8ing2low
 	LD	(mseprt),A
 	CALL	chms0
 	JR	NC,found
-	LD	A,#60	;ingang2,pin8ingang2 hoog,pin8ing1laag
+	LD	A,#60	;input2,pin8input2 high,pin8ing1low
 	LD	(mseprt),A
 	CALL	chms0
-	RET	C	;geen muis aangesloten
+	RET	C	;no mouse connected
 found	PUSH	IX
-	LD	A,(stat_getkey)	;1=check muisvuurknoppen only
+	LD	A,(stat_getkey)	;1=check mouse fire buttons only
 	OR	A
 	JR	Z,_found
 	LD	A,(trgflg)
-	AND	#50	;get 1e vuurknoppen port1 en port2
-	CP	#50	;1 van beide ingedrukt?
-	JR	Z,no_fire1	;neen, geen van beide ingedrukt
-_found	PUSH	HL	;bewaar muisoffsets
+	AND	#50	;get 1st fire buttons port1 and port2
+	CP	#50	;1 of the two pressed?
+	JR	Z,no_fire1	;no, neither of them pressed
+_found	PUSH	HL	;save mouse offsets
 	LD	IX,OFFSTX
 	LD	A,L
 	LD	DE,28*256+29
-	CALL	count	;zet L/R karakters in keybuffer
+	CALL	count	;put L/R characters in keybuffer
 	POP	HL
 	INC	IX
 	INC	IX
 	INC	IX
 	LD	A,H
 	LD	DE,31*256+30
-	CALL	count	;zet U/D karakters in keybuffer
+	CALL	count	;put U/D characters in keybuffer
 no_fire1	ld	ix,frfake
 	CALL	fire1
 	CALL	fire2
@@ -5811,11 +5811,11 @@ fire1	LD	A,(fr1)
 	ld	a,(trgflg)
 	AND	#50
 	CP	B
-	RET	Z	;ja, nog steeds dezelfde stand
+	RET	Z	;yes, still the same position
 	LD	(fr1),A
 	CP	#50
-	RET	Z	;vuurknop1 not pushed
-	LD	D,#00	;plaats karakter nul in toetsbuf
+	RET	Z	;fire button1 not pushed
+	LD	D,#00	;put character zero in keybuf
 _fire1	LD	B,#01
 	JP	cntend
 fr1	db	0
@@ -5828,11 +5828,11 @@ fire2	LD	A,(fr2)
 	LD	(fr2),A
 	CP	#A0
 	RET	Z
-	LD	D,#01	;plaats karakter 1 in toetsenbordbuf
+	LD	D,#01	;put character 1 in keyboard buffer
 	JR	_fire1
 fr2	db	0
 frfake	db	0,0,1
-chms0	ld	b,8	;check 8 keer
+chms0	ld	b,8	;check 8 times
 chms1	CALL	getpad
 	LD	A,H
 	CP	#01
@@ -5843,25 +5843,25 @@ chms1	CALL	getpad
 	DJNZ	chms1
 	SCF
 	RET
-chms2	AND	A	;wis carry
+chms2	AND	A	;clear carry
 	RET
 
-count	BIT	7,A	;offset negatief?
+count	BIT	7,A	;offset negative?
 	JR	NZ,_cntdown
 	ADD	A,(IX+#00)
 	LD	B,A
 	AND	#07
-	LD	(IX+#00),A	;bewaar het aantal restpixels
+	LD	(IX+#00),A	;save the remaining pixels
 	SRL	B
 	SRL	B
 	SRL	B
-	RET	Z	;aantal volledig gemovede vakken in B
-cntend	LD	HL,(#F3F8)	;op deze plek moet nieuw teken
-cntu_skip	INC	(IX+#01)	;om de (ix+2) tekens pas een byte
-	LD	A,(IX+#02)	;in de keybuffer steken
-	CP	(IX+#01)	;dient om de muis wat te vertragen
+	RET	Z	;number of fully moved courses in B
+cntend	LD	HL,(#F3F8)	;this place needs a new sign
+cntu_skip	INC	(IX+#01)	;every (ix+2) characters put a byte
+	LD	A,(IX+#02)	;in the key buffer
+	CP	(IX+#01)	;serves to slow down the mouse a bit
 	JR	NZ,skip_ureset
-	LD	(IX+#01),#00	;teller weer op nul
+	LD	(IX+#01),#00	;counter back to zero
 	LD	A,D
 	CALL	putkeybuf
 skip_ureset	DJNZ	cntu_skip
@@ -5874,14 +5874,14 @@ putkeybuf	LD	(HL),A
 	RET	NZ
 	LD	HL,#FBF0
 	RET
-_cntdown	NEG		;maak positief
-	LD	L,A	;l=aantal pixel om eraf te trekken
+_cntdown	NEG		;make positive
+	LD	L,A	;l=number of pixels to subtract
 	LD	A,(IX+#00)
-	LD	H,A	;h en a=aantal restpixels
-	SUB	L	;bereken nieuw aantal restpixels
+	LD	H,A	;h and a=number of remaining pixels
+	SUB	L	;calculate new number of remaining pixels
 	AND	#07
-	LD	(IX+#00),A	;en sla op
-	LD	A,#07	;aantal pixels over berekenen
+	LD	(IX+#00),A	;and save
+	LD	A,#07	;number of pixels for calculation
 	SUB	H
 	ADD	A,L
 	SRL	A
@@ -5909,7 +5909,7 @@ OFFSTY	db	0
 OFFS1	db	0
 MAXOF1	db	1
 
-;get paddle data offsets:uit: HL #yyxx offsets  in: mseprt
+;get paddle data offsets:out: HL #yyxx offsets  in: mseprt
 getpad	PUSH	BC
 	PUSH	DE
 	LD	DE,(mseprt)
@@ -5920,35 +5920,35 @@ getpad	PUSH	BC
 	IN	A,(#A2)
 	AND	#8F
 	OR	E
-	LD	E,A	;te schrijven byte in E
+	LD	E,A	;byte to write in E
 	LD	B,40	;delay z80
 	LD	C,20	;delay r800
-	CALL	gpad2	;haal bovenste 4 bits
-	CALL	gpad0	;haal onderste 4 bits en zet alles in A
+	CALL	gpad2	;get top 4 bits
+	CALL	gpad0	;get bottom 4 bits and put everything in A
 	LD	L,A	;xoffset
-	CALL	gpad1	;haal direct de 4 bovenste bits
-	CALL	gpad0	;haal direct de 4 onderste bits
+	CALL	gpad1	;get the top 4 bits right away
+	CALL	gpad0	;get the lower 4 bits right away
 	LD	H,A	;yoffset
 	POP	DE
 	POP	BC
 	RET
-gpad0	RLCA		;doe gelezen waarde *16
+gpad0	RLCA		;do read value *16
 	RLCA
 	RLCA
 	RLCA
 	LD	D,A
-	CALL	gpad1	;lees onderste mousebits vrijwel direct
+	CALL	gpad1	;read bottom mouse bits directly
 	OR	D
-	NEG		;corrigeer
+	NEG		;correct
 	RET
-gpad1	LD	BC,#0708	;korte delay
+gpad1	LD	BC,#0708	;short delay
 gpad2	LD	A,#0F
 	OUT	(#A0),A
 	LD	A,E
 	OUT	(#A1),A
 	LD	A,(mseprt)
-	AND	#30	;haal ingang: #20=2 #10=1
-	XOR	E	;inverteer de pin8bit
+	AND	#30	;get input: #20=2 #10=1
+	XOR	E	;invert the pin8bit
 	LD	E,A
 invul_delay	CALL	0
 	LD	A,#0E
@@ -5960,12 +5960,12 @@ invul_delay	CALL	0
 	RET
 delay_Z80	DJNZ	delay_Z80
 	RET
-delay_R800	IN	A,(#E6)	;get lowbyte TurboR systemtimer
+delay_R800	IN	A,(#E6)	;get lowbyte TurboR system timer
 	LD	B,A
 _delay_R800	IN	A,(#E6)
-	SUB	B	;hoeveel is de teller al hoger?
-	CP	C	;nog minder dan we moeten hebben?
-	JR	C,_delay_R800	;ja, nog wachten
+	SUB	B	;how much is the counter already higher?
+	CP	C	;even less than we need?
+	JR	C,_delay_R800	;yes, still waiting
 	RET
 fill_delay	LD	HL,delay_Z80
 	LD	A,(msxtype)
@@ -5980,25 +5980,25 @@ fill_delay	LD	HL,delay_Z80
 _fill_delay	LD	(invul_delay+1),HL
 	RET
 
-janeetoetsen	LD	A,(msxtype)	;enkel en alleen turboR
+janeetoetsen	LD	A,(msxtype)	;only turboR
 	CP	#03
 	RET	NZ
 	DI
-	IN	A,(#AA)	;zet rijnummer 11
+	IN	A,(#AA)	;put row number 11
 	AND	#F0
 	OR	#0B
 	NOP
 	OUT	(#AA),A
 	NOP
 	NOP
-	IN	A,(#A9)	;lees rij
+	IN	A,(#A9)	;read row
 	CPL
 	AND	#0A
-	ret	z	;noch ja,noch nee
+	ret	z	;neither yes nor no
 	ld	b,#80
 	bit	3,a
-	jr	nz,zetcpu	;neetoets
-	inc	b	;jatoets
+	jr	nz,zetcpu	;no test
+	inc	b	;yes test
 zetcpu	ld	a,b
 	PUSH	IX
 	LD	IX,#0180
@@ -6007,20 +6007,20 @@ zetcpu	ld	a,b
 	RET
 hertztoetsen	LD	A,(matrix+6)
 	AND	#02
-	RET	NZ	;ctrl niet ingedrukt
+	RET	NZ	;ctrl not pressed
 	LD	A,(matrix)
 	RLCA
 	RLCA
 	LD	B,#80
-	JR	NC,zetspeed	;6toets ingedrukt
+	JR	NC,zetspeed	;6key pressed
 	RLCA
-	RET	C	;5toets niet ingedrukt
+	RET	C	;5key not pressed
 	LD	B,#82
 zetspeed	DI
-	LD	A,(#FFE8)	;lees vdp10
+	LD	A,(#FFE8)	;read vdp10
 	AND	#7D
-	OR	B	;zet bit 2 naargelang, bit7 high (212)
-	LD	(#FFE8),A	;schrijf weg
+	OR	B	;set bit 2 sorted, bit7 high (212)
+	LD	(#FFE8),A	;write away
 	OUT	(#99),A
 	LD	A,#89
 	OUT	(#99),A
@@ -6052,14 +6052,14 @@ databuffer4	ds	13,0
 labelbuffer	ds	9,0
 
 ;**************************************************************************
-;alles vanaf hier wordt gewist (routines voor 1malig gebruik bij opstarten)
+;everything from here will be erased (one time use routines on startup)
 buffer1024
 
 hook	jr	hookcontinue
 hook_slot	db	0
 hook_blok	db	0
 cmd_id	db	"COMPASS",0	;ID
-hook_tab_tpa	db	0,0,0,0	;wordt ingevuld door startcompass
+hook_tab_tpa	db	0,0,0,0	;is filled in by start compass
 tab_tpa	equ	hook_tab_tpa-hook+hookadres
 hook_tab_cur	db	0,0,0,0	;idem
 current_p0	equ	hook_tab_cur-hook+hookadres
@@ -6083,7 +6083,7 @@ hook_hoofd	LD	A,(hook_slot-hook+hookadres)
 	LD	H,#80
 	CALL	#0024
 	LD	A,(hook_blok-hook+hookadres)
-	call	SETPAGE2_DOS2	;bloknr goedzetten
+	call	SETPAGE2_DOS2	;correct block number
 	call	SETPAGE0_DOS2
 	POP	AF
 	CALL	#8000+set_slot_p0
@@ -6099,15 +6099,15 @@ test_cmd	LD	A,(DE)
 	OR	A
 	JR	Z,end_test
 	LD	B,A
-	RST	#10	;haal karakter van de commandoline
-	AND	#DF	;verander kleine letters naar hoofdlet.
+	RST	#10	;get character from command line
+	AND	#DF	;change lowercase to uppercase.
 	CP	B
 	JR	Z,test_cmd
 end_test	POP	HL
 	POP	DE
 	POP	BC
-	JR	Z,hook_hoofd	;waarom wordt af niet meer afgehaald???
-	POP	AF	;antw: stack doet er niet meer toe, en om flags niet te verknoeien
+	JR	Z,hook_hoofd	;why isn't it picked up anymore???
+	POP	AF	;answer: stack doesn't matter anymore, and so as not to mess flags
 orighookcmd	ds	5,0
 hook_back	LD	A,(#FCC1)
 	LD	H,#00
@@ -6138,56 +6138,56 @@ _hook_feda1	POP	BC
 hook_text	db	10,"Press [SHIFT] + [ESC] or type CMD COMPASS "
 	db	"to return.",10,0
 getpage0_dos2	db	#3a	;ld a,(nn)
-fill_getpage0	dw	current_p0	;onder dos2:f2c7
+fill_getpage0	dw	current_p0	;under dos2:f2c7
 	RET
 GETPAGE0_DOS2	equ	getpage0_dos2-hook+hookadres
 getpage1_dos2	db	#3a
-fill_getpage1	dw	current_p1	;onder dos2:f2c8
+fill_getpage1	dw	current_p1	;under dos2:f2c8
 	RET
 GETPAGE1_DOS2	equ	getpage1_dos2-hook+hookadres
 getpage2_dos2	db	#3a
-fill_getpage2	dw	current_p2	;onder dos2:f2c9
+fill_getpage2	dw	current_p2	;under dos2:f2c9
 	RET
 GETPAGE2_DOS2	equ	getpage2_dos2-hook+hookadres
 setpage0_dos2	db	#32	;ld (nn),a
-fill_setpage0	dw	current_p0	;onder dos2:f2c7
+fill_setpage0	dw	current_p0	;under dos2:f2c7
 	OUT	(#FC),A
 	RET
 SETPAGE0_DOS2	equ	setpage0_dos2-hook+hookadres
 setpage1_dos2	db	#32
-fill_setpage1	dw	current_p1	;onder dos2:f2c8
+fill_setpage1	dw	current_p1	;under dos2:f2c8
 	OUT	(#FD),A
 	RET
 SETPAGE1_DOS2	equ	setpage1_dos2-hook+hookadres
 setpage2_dos2	db	#32
-fill_setpage2	dw	current_p2	;onder dos2:f2c9
+fill_setpage2	dw	current_p2	;under dos2:f2c9
 	OUT	(#FE),A
 	RET
 SETPAGE2_DOS2	equ	setpage2_dos2-hook+hookadres
 hook_end
 
-fill_inst	LD	A,(kbuf)	;maagdelijke versie?
+fill_inst	LD	A,(kbuf)	;virgin version?
 	OR	A
 	RET	Z
-	LD	A,(kbuf+#104)	;nee, haal installations
-	LD	(Backuponoff),A	;bewaar backupstatus
-	ld	a,(kbuf+1)	;werd er een search mem gedaan in de COM?
+	LD	A,(kbuf+#104)	;no, get installations
+	LD	(Backuponoff),A	;save backup status
+	ld	a,(kbuf+1)	;was there a search mem done in the COM?
 	or	a
-	jr	z,work_default	;zoja,installeer dan niet de gesavede
-	LD	HL,kbuf+#cb	;memoryinstelling (gebruik default)
-	LD	DE,tab_memory	;de default wordt ingevuld door
-	LD	BC,8	;startcompass
+	jr	z,work_default	;if so don't install the saved one
+	LD	HL,kbuf+#cb	;memory setting (use default)
+	LD	DE,tab_memory	;the default is filled in by
+	LD	BC,8	;starting compass
 	LDIR
-work_default	LD	HL,(kbuf+#ec)	;paletbytes color 0,(0)
+work_default	LD	HL,(kbuf+#ec)	;palettebytes color 0,(0)
 	LD	(color),HL
-	LD	HL,(kbuf+#ee)	;paletbytes color 1,(15)
+	LD	HL,(kbuf+#ee)	;palettebytes color 1,(15)
 	LD	(color+30),HL
-	LD	HL,(kbuf+#f0)	;paletbytes color 2,(3)
+	LD	HL,(kbuf+#f0)	;palettebytes color 2,(3)
 	LD	(color+6),HL
-	LD	HL,(kbuf+#f2)	;paletbytes color 3,(2)
+	LD	HL,(kbuf+#f2)	;palettebytes color 3,(2)
 	LD	(color+4),HL
 	CALL	setcolors
-	LD	HL,kbuf+#d3	;idhex,idbin,mouse,knipper,logo
+	LD	HL,kbuf+#d3	;idhex,idbin,mouse,clipper,logo
 	LD	DE,tab_inst
 	LD	BC,#19
 	LDIR
@@ -6258,7 +6258,7 @@ bios	JP	SETVRAMWRITE	;080
 	JP	GETKEY2
 endbios
 
-codename	ds	88*2,0	;88 bytes*2lijnen
+codename	ds	88*2,0	;88 bytes*2lines
 
 startcompass	di
 	ld	(#8000+si_place1),hl
@@ -6275,32 +6275,32 @@ startcompass	di
 	LD	DE,hookadres
 	LD	BC,hook_end-hook
 	LDIR
-	LD	HL,#C000	;ROMRAMtabel
+	LD	HL,#C000	;ROMRAMtable
 	LD	DE,#8000+tab_ROMRAM
 	LD	BC,#60
 	LDIR
-	LD	DE,#8000+tab_memtabel	;mem_tabel
+	LD	DE,#8000+tab_memtabel	;mem_table
 	LD	BC,#C1
 	LDIR
-	LD	DE,#8000+tab_compass	;compassblocks
+	LD	DE,#8000+tab_compass	;compass blocks
 	LD	BC,8
 	LDIR
 	ld	de,tab_tpa
 	ld	bc,4
 	ldir
-	LD	A,(#8000+slothoofdp)	;haal slotcode
+	LD	A,(#8000+slothoofdp)	;get slot code
 	LD	(hook_slot-hook+hookadres),A
 	LD	H,#00
 	CALL	#0024
-	LD	A,(#8000+slothoofdp+1)	;haal bloknr
+	LD	A,(#8000+slothoofdp+1)	;get block num
 	LD	(hook_blok-hook+hookadres),A
 	ld	(current_p0),a
 	OUT	(#FC),A
-	;vanaf nu geen +#8000 meer nodig
+	;from now on no more +#8000 needed
 	ld	(current_p2),a
 	ld	a,(tab_tpa+3)
 	ld	(current_p3),a
-	ld	a,(tab_compass+7)	;het laatste ingeladen segment
+	ld	a,(tab_compass+7)	;the last loaded segment
 	ld	(current_p1),a
 	LD	A,(dosversion)
 	CP	#02
@@ -6321,14 +6321,14 @@ startcompass	di
 	jr	no_change
 dos1versie	ld	hl,(#f349)
 	ld	(oldf349),hl
-	ld	hl,(#f34b)	;dosinterrupt,etc veilig stellen bij return to BASIC
+	ld	hl,(#f34b)	;secure dosinterrupt,etc on return to BASIC
 	ld	(#f349),hl
 	ld	(newf349),hl
-no_change	LD	A,(#FCC1)	;zet msxtype in onze eigen bios
+no_change	LD	A,(#FCC1)	;put msxtype in our own bios
 	LD	HL,msxtype
 	CALL	#000C
 	LD	(msxtype),A
-	CALL	chk_comline	;zet filename ev. in vram
+	CALL	chk_comline	;put filename in vram
 	ld	hl,bios
 	ld	de,#0080
 	ld	bc,endbios-bios
@@ -6336,16 +6336,16 @@ no_change	LD	A,(#FCC1)	;zet msxtype in onze eigen bios
 	ld	hl,#fcc4
 	ld	b,4
 	xor	a
-_startcompass	or	(hl)	;aanmaken speciale byte voor debugger
-	rlca		;bit0-3: 1 als bijhorend slot geexp is
+_startcompass	or	(hl)	;create special byte for debugger
+	rlca		;bit0-3: 1 if corresponding slot is exp
 	dec	hl
 	djnz	_startcompass
 	ld	(debuggerreg),a
 	LD	HL,codename
 	LD	DE,#0A00
-	LD	BC,11*8*2	;voor twee lijnen
+	LD	BC,11*8*2	;for two lines
 	CALL	RAMTOVRAM
-	LD	A,(#FCC1)	;zet default werkgeheugeninstelling
+	LD	A,(#FCC1)	;set default working memory setting
 	LD	(page0),A
 	LD	A,(#F344)
 	LD	(page1),A
@@ -6367,5 +6367,5 @@ _startcompass	or	(hl)	;aanmaken speciale byte voor debugger
 	ld	(page3+1),a
 	jp	shellentry
 
-	ds	#4000-$,0	; (voor de zekerheid opvullen met nop)
+	ds	#4000-$,0	;(fill with padding just to be sure)
 

--- a/Compass129Sources/DATfile/MAKEDAT.ASC
+++ b/Compass129Sources/DATfile/MAKEDAT.ASC
@@ -1,15 +1,15 @@
-;programma dat dient om compass.dat #1.2.xx aan te maken
-;voor dos 1 en 2
+;program to create compass.dat #1.2.xx
+;for dos 1 and 2
 
-	;invoer
-	;main.dat:#3ec0:moet het hoofdprogramma bevatten (bios,etc)
+	;input
+	;main.dat:#3ec0:must contain the main program (bios,etc)
 	;editor.dat:#4000
-	;asmrout.dat:#3000:assembleerroutine
+	;asmrout.dat:#3000:assemblerroutine
 	;monitor.dat:#1000:monitor
 	;debugger.dat:#4000
 
 bdos	equ	#0005
-headln	equ	128	;lengte van header
+headln	equ	128	;length of header
 
 	org	#0100
 	ld	de,txt_info
@@ -42,7 +42,7 @@ nouitleg	ld	hl,(#0082)
 	ld	de,#8000
 	ld	bc,headln
 	ldir
-	ld	de,fcb_datfile	;schrijf header
+	ld	de,fcb_datfile	;write header
 	ld	hl,headln
 	ld	c,38
 	call	bdos
@@ -128,7 +128,7 @@ voegtoe	push	hl
 	ld	hl,(lengte)
 	ld	de,fcb
 	ld	c,39
-	call	bdos	;lees datablok
+	call	bdos	;read data block
 	OR	A
 	scf
 	ret	nz
@@ -144,7 +144,7 @@ voegtoe	push	hl
 	ld	de,fcb_datfile
 	ld	hl,(lengte)
 	ld	c,38
-	CALL	bdos	;schrijf
+	CALL	bdos	;write
 	OR	A
 	ret	z
 	scf

--- a/Compass129Sources/DATfile/MON12.ASC
+++ b/Compass129Sources/DATfile/MON12.ASC
@@ -1,6 +1,6 @@
 ;Compass v1.2.02 Monitor 08/07/1998
 
-kbuf:	equ	#f41f	;buffer van 318 bytes
+kbuf:	equ	#f41f	;318 byte buffer
 
 setvramwrite:	equ	#80
 fillvram:	equ	#89
@@ -18,7 +18,7 @@ inputtext:	equ	#bf
 printmenu:	equ	#c5
 kiesoptie:	equ	#c8
 wisoudmenu:	equ	#cb
-berekengetal:	equ	#d1	;voor rekenmachine (?)
+berekengetal:	equ	#d1	;for calculator (?)
 memview:	equ	#d4
 calculator:	equ	#d7
 memory:	equ	#da
@@ -30,7 +30,7 @@ waitforkey:	equ	#10a
 gotodebugger	equ	#113
 maininstall:	equ	#116
 
-msxtype:	equ	#2d	;zelf geplaatst !
+msxtype:	equ	#2d	;self posted !
 Cursoronoff:	equ	#fca9
 Matrix:	equ	#fbe5
 Escape:	equ	27
@@ -54,7 +54,7 @@ Ctrl_q:	equ	1+"Q"-"A"
 Ctrl_x	equ	1+"X"-"A"
 Ctrl_z:	equ	1+"Z"-"A"
 
-SETGETADRES	equ	#4012	;in debuggersegment
+SETGETADRES	equ	#4012	;in debugger segment
 
 	org	#7000
 
@@ -72,7 +72,7 @@ _nietturbor	ld	(Turbor),a
 	call	nz,newchaining
 	jp	monitortek
 
-Turbor	db	0	;0=niet ,1=wel
+Turbor	db	0	;0=not ,1=yes
 chaining	db	0	;default: unchained
 
 back	push	af
@@ -102,7 +102,7 @@ GOdebsetgetad	push	hl
 	ld	hl,SETGETADRES
 	jp	gotodebugger
 
-;----- Verander funktietoetsen: F1=255, F2=254, F3=253, F4=252, F5=251
+;----- Change function keys: F1=255, F2=254, F3=253, F4=252, F5=251
 changefkey	ld	hl,#f87f
 	ld	de,16-1
 	ld	ix,Oldfkey
@@ -121,7 +121,7 @@ _changefkey1	dec	c
 	djnz	_changefkey1
 	ret
 Oldfkey	ds	10
-;----- Herstel funktietoetsen
+;----- Restore function Keys
 oldfkey	ld	hl,#f87f
 	ld	de,16-1
 	ld	ix,Oldfkey
@@ -136,7 +136,7 @@ _oldfkey1	ld	a,(ix)
 	add	hl,de
 	djnz	_oldfkey1
 	ret
-;----- Test of B=funktietoets, zo ja: C=menunr (1-5) en [NC]
+;----- Test whether B=function key, if so: C=menu num (1-5) and [NC]
 testfkey	ld	a,b
 	cp	251
 	ret	c
@@ -145,7 +145,7 @@ testfkey	ld	a,b
 	ld	c,a
 	xor	a
 	ret
-;--------------- Menu's
+;--------------- Menus
 lastmenu	ld	a,(Lastmenu)
 	ld	c,a
 	jr	startmenu
@@ -250,7 +250,7 @@ areyousure	ld	bc,Areyousure
 	ret
 Areyousure:	db	"Are you sure ? (y/n)",0
 
-Menu1	db	8,13,0	;hoogte,breedte tekst,plaats ondergrond
+Menu1	db	8,13,0	;height, width text, place background
 	db	"Assembler    "
 	db	"Debugger     "
 	db	"Disk       ^D"
@@ -323,7 +323,7 @@ _addressstrt	ld	hl,11*80+20
 	call	zetadres
 	jp	monitor
 
-zetadres:	;zet adres en monitorcursor (IN: DE=adres)
+zetadres:	;set address and monitor cursor (IN: DE=address)
 	ld	h,d
 	ld	a,e
 	and	%00001111
@@ -334,7 +334,7 @@ zetadres:	;zet adres en monitorcursor (IN: DE=adres)
 	and	%11110000
 	ld	l,a
 	ld	bc,#80
-	sbc	hl,bc	;staat op [NC]
+	sbc	hl,bc	;is set to [NC]
 	ld	(Beginadres),hl
 	ret
 Hokaddr	dw	H1,H2,H3,0
@@ -482,20 +482,20 @@ zethoksearch	ld	hl,9*80+20
 	call	inputbin
 	ld	(Startsearch),de
 	xor	a
-	ld	(Searchnext),a	;LATEN STAAN !
+	ld	(Searchnext),a	;LEAVE !
 _search2	ld	hl,13*80+32
 	call	inputbin
 	ld	(Stopsearch),de
 	ex	de,hl
 	ld	de,(Startsearch)
-	sbc	hl,de	;staat op [NC]
+	sbc	hl,de	;[NC] is set
 	jr	c,_search2	;Stop < Start
 	xor	a
 	ld	(kbuf),a
 _search1	ld	hl,14*80+32
 	ld	bc,25
 	xor	a
-	call	fillvram	;ZO LATEN !
+	call	fillvram	;LEAVE IT !
 	ld	hl,14*80+32
 	ld	bc,kbuf
 	call	printtekst
@@ -510,11 +510,11 @@ _search1	ld	hl,14*80+32
 	push	ix
 	pop	hl
 	ld	de,Searchstring
-	sbc	hl,de	;staat op [NC]
+	sbc	hl,de	;[NC] is set
 	ld	(Lengthstring),hl
 	ld	a,1
 	ld	(Searchnext),a
-_searchnext	ld	hl,(Stopsearch)	;Haal volgende blok uit Ram
+_searchnext	ld	hl,(Stopsearch)	;Get next block from Ram
 	ld	de,(Startsearch)
 	ld	a,d
 	or	e
@@ -537,20 +537,20 @@ _searchnext1	or	a
 	ld	bc,512
 _searchl1	ld	(Huidiglengte),bc
 	ld	hl,(Bufferpage0)
-_searchcont	ld	a,b	;Zoek volgende 1e element
+_searchcont	ld	a,b	;Find next 1st element
 	or	c
-	jr	z,_searchnfnd	;Voor CONT !
+	jr	z,_searchnfnd	;For CONT !
 	ld	a,(Searchstring)
 	cpir
 	jr	z,_searchfnd
-	;1e element niet gevonden => volgende blok ram
+	;1st element not found => next block ram
 _searchnfnd	ld	hl,(Startsearch)
 	ld	bc,(Huidiglengte)
 	add	hl,bc
 	ld	(Startsearch),hl
 	jr	c,_searchready
 	jr	_searchnext
-	;1e element gevonden => test rest
+	;1st element found => test rest
 _searchfnd	ld	(Cpiradres),hl
 	ld	(Cpirlengte),bc
 	ex	de,hl
@@ -559,7 +559,7 @@ _searchfnd	ld	(Cpiradres),hl
 	dec	bc
 	or	a
 	sbc	hl,bc
-	jr	c,_searchready	;rest te klein voor string
+	jr	c,_searchready	;rest too small for string
 	ex	de,hl
 	ld	b,c
 	ld	a,b
@@ -573,10 +573,10 @@ _searchrest2	ld	a,(de)
 	jr	nz,_searchrest1
 	djnz	_searchrest2
 	jr	_stringfound
-_searchrest1	ld	hl,(Cpiradres)	;Rest van de string klopt niet
+_searchrest1	ld	hl,(Cpiradres)	;Rest of the string is incorrect
 	ld	bc,(Cpirlengte)
 	jr	_searchcont
-_searchready	xor	a	;String niet gevonden
+_searchready	xor	a	;String not found
 	ld	(Searchnext),a
 	ld	hl,12*80+(80-18)/2
 	ld	bc,Stringnfound
@@ -593,7 +593,7 @@ _stringfound	ld	hl,(Cpiradres)
 	sbc	hl,de
 	ld	de,(Startsearch)
 	add	hl,de
-	ld	(Startsearch),hl	;voor Search next !
+	ld	(Startsearch),hl	;for Search next !
 	ex	de,hl
 	dec	de
 	call	zetadres
@@ -625,7 +625,7 @@ Searchtext1	dw	12*80+24
 	jp	nz,_searchnext
 	call	beep
 	jp	monitor
-Searchnext	db	0	;mogelijk ? => 0=nee, 1=ja
+Searchnext	db	0	;possible ? => 0=no, 1=yes
 
 !fill	ld	hl,9*80+20
 	ld	de,Hokfill
@@ -718,7 +718,7 @@ _inputblok1	ld	hl,13*80+31
 	ld	(Stopblok),de
 	ex	de,hl
 	ld	de,(Startblok)
-	sbc	hl,de	;staat op [NC]
+	sbc	hl,de	;[NC] is set
 	jr	c,_inputblok1	;Stop < Start
 	ret
 Startblok	defw	0
@@ -1029,7 +1029,7 @@ _print1	ld	hl,14*80+35
 	ld	a,b
 	ld	(Leegascii+1),a
 	ld	a,16
-	sub	b	;A = aantal nog te printen
+	sub	b	;A = quantity yet to be printed
 	ld	b,a
 	ld	hl,(Stopblok)
 	inc	hl
@@ -1038,14 +1038,14 @@ _print1	ld	hl,14*80+35
 	sbc	hl,de
 	ld	a,h
 	or	a
-	jr	nz,_print4	;restlengte lang genoeg
+	jr	nz,_print4	;residual length long enough
 	ld	a,l
 	cp	b
 	jr	nc,_print4
 	ld	b,l
 _print4	push	bc
 	call	doprthex
-Leegascii:	ld	b,0	;ingevuld !!!
+Leegascii:	ld	b,0	;filled in !!!
 	ld	a,b
 	or	a
 	jr	z,_noleegasc
@@ -1186,7 +1186,7 @@ Printtext	dw	10*80+38
 	db	"Print",0
 	dw	0
 
-Menu3	db	8,14,0	;hoogte,breedte tekst,plaats ondergrond
+Menu3	db	8,14,0	;height, width text, place background
 	db	"Search      ^Z"
 	db	"Search next ^N"
 	db	"Fill        ^F"
@@ -1261,18 +1261,18 @@ M3	db	1,20,78,23,1,19,0
 M4	db	1,26,78,23,1,27,0
 M5	db	80,0,0
 
-;---------- HOOFDPROGRAMMA MONITOR
+;---------- MAIN PROGRAM MONITOR
 Mon_x	defb	0
 Mon_y	defb	8
-Hex_ascii	defb	0	;0=hex, 1=ascii-gedeelte
+Hex_ascii	defb	0	;0=hex, 1=ascii part
 
 monitortek	call	tekenscherm
 monitor	ld	sp,(Sp_back)
 monloop	call	setcursor
-	ei		;wacht op eventueel op toetsen
+	ei		;wait for possible keys
 	halt
 	ld	b,0
-	call	waitforkey	;wacht 0 interrupts op toets
+	call	waitforkey	;wait 0 interrupts for keys
 	jr	nc,montesttoets
 	call	printmon
 	jr	monloop
@@ -1417,7 +1417,7 @@ testtoets	ld	a,(hl)
 	inc	hl
 	jr	nz,testtoets
 	ex	de,hl
-	pop	de	;CALL wegwerken
+	pop	de	;get rid of CALL
 	ld	a,1
 	ld	(Cursoronoff),a
 	push	hl
@@ -1543,7 +1543,7 @@ printmon	call	berramadres
 	ld	de,(Beginadres)
 	exx
 	ld	hl,4*80+3
-	ld	de,80	;een een constante
+	ld	de,80	;a a constant
 	ld	b,16
 _printmon1	call	setvramwrite
 	exx
@@ -1554,7 +1554,7 @@ _printmon1	call	setvramwrite
 	ld	b,3
 _tussen1	ld	a," "
 	out	(#98),a
-	nop		;!voor op TR
+	nop		;!for TR
 	nop
 	djnz	_tussen1
 	push	hl
@@ -1569,13 +1569,13 @@ _printmon3	ld	a,(hl)
 	ld	b,3
 _tussen2	ld	a," "
 	out	(#98),a
-	nop		;!voor op TR
+	nop		;!for TR
 	nop
 	djnz	_tussen2
 	ld	bc,#1098
 _printmon4	outi
 	inc	de
-	nop		;!voor Turbo-R
+	nop		;!for Turbo-R
 	jr	nz,_printmon4
 	exx
 	add	hl,de
@@ -1596,7 +1596,7 @@ _printhex2:	cp	10
 _printhex1:	add	a,"0"
 	out	(#98),a
 	ret
-Beginadres	dw	#bf80	;Beginadres ! (altijd bovenaan)
+Beginadres	dw	#bf80	;Start address ! (always on top)
 
 berramadres	ld	de,(Mon_x)	;E=x, D=y
 	ld	l,d
@@ -1660,10 +1660,10 @@ _defb_tekst	push	ix
 	jr	z,_weltekst
 	cp	"'"
 	jr	nz,_notekst
-_weltekst	ld	b,a	;" of '
+_weltekst	ld	b,a	;" or '
 	cp	(hl)
 	ld	a,0
-	jr	z,_2quotes	;"" of '' = 0
+	jr	z,_2quotes	;"" or '' = 0
 _defb_tekst1	ld	a,(hl)
 	inc	hl
 	cp	b
@@ -1696,7 +1696,7 @@ getal8bit	call	berekengetal
 	or	a
 	ret
 
-Bufferpage0	defw	0	;adres buffer in page 0
+Bufferpage0	defw	0	;address buffer in page 0
 
 
 	ds	#7FF0-$,0


### PR DESCRIPTION
The original code comments are written in Dutch. This pull request translates them to English.

I made a small program to run through all the source code lines, detect the comments and pass them to the Google translator API. Thus, it's mostly machine translation work, although I did a light manual review in order to detect obvious translation mistakes (e.g. "slot" had often been translated as "lock" for some reason).

A thorough review from a native Dutch speaker would be highly welcome to turn this into a top-notch translation work. Bonus points if someone would like to translate the Dutch labels as well.

**EDIT**

Comments in `C12COM9.ASC` already reviewed, thanks @FiXato!